### PR TITLE
feat: logging using `log` crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "futures",
  "glyphon",
  "image",
+ "log",
  "lyon",
  "wgpu",
  "winit",
@@ -1139,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "grafo"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ahash = "0.8.11"
 lyon = "1.0.1"
 glyphon = "0.7.0"
 easy-tree = { version = "0.1.3", features = ["rayon"] }
+log = "0.4.22"
 
 [dev-dependencies]
 winit = "0.29.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafo"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "A GPU-accelerated rendering library for Rust"
 keywords = ["rendering", "vector_graphics", "gui", "graphics", "image"]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Grafo documentation](https://docs.rs/grafo/badge.svg)](https://docs.rs/grafo)
 [![Build and test](https://github.com/antouhou/grafo/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/antouhou/grafo/actions)
 
-Grafo is a GPU-accelerated rendering library for Rust. 
-Leveraging the power of the `wgpu` crate, Grafo provides efficient rendering of shapes, images, 
-and text with support for advanced features like stencil operations and parallel processing.
+Grafo is a GPU-accelerated rendering library for Rust. It is a one-stop solution in case 
+you need a quick and simple way to render shapes, images, and text in your application. It 
+supports features such as masking, clipping, and font loading and rendering.
 
 The library is designed for flexibility and ease of use, making it suitable for a wide 
 range of applications, from simple graphical interfaces to complex rendering engines.
@@ -15,10 +15,9 @@ range of applications, from simple graphical interfaces to complex rendering eng
 
 * Shape Rendering: Create and render complex vector shapes. 
 * Image Rendering: Render images with support for clipping to shapes. 
-* Text Rendering: Render text with customizable layout, alignment, and styling using the 
+* Text Rendering: Load fonts and render text with customizable layout, alignment, and styling using the 
 [glyphon](https://github.com/grovesNL/glyphon) crate. 
-* Stencil Operations: Advanced stencil operations for clipping and masking. 
-* Performance Optimization: Utilizes parallel processing with `rayon` to optimize rendering performance.
+* Stencil Operations: Advanced stencil operations for clipping and masking.
 
 Grafo [available on crates.io](https://crates.io/crates/grafo), and
 [API Documentation is available on docs.rs](https://docs.rs/grafo/).

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -616,8 +616,6 @@ impl Renderer<'_> {
     /// }
     /// ```
     pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
-        println!("===============");
-        let first_timer = Instant::now();
         let draw_tree_size = self.draw_tree.len();
         let iter = self.draw_tree.par_iter_mut();
 
@@ -636,12 +634,6 @@ impl Renderer<'_> {
             }
         });
 
-        println!(
-            "Iterating over the draw tree of {} elements took: {:?}",
-            self.draw_tree.len(),
-            first_timer.elapsed()
-        );
-
         // TODO: this is for debugging purposes
         // let query_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
         //     label: Some("Query Buffer"),
@@ -656,7 +648,6 @@ impl Renderer<'_> {
         //     usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
         //     mapped_at_creation: false,
         // });
-        println!("Creating buffers took: {:?}", first_timer.elapsed());
 
         // TODO: this is for debugging purposes
         // let encoder_timer = Instant::now();
@@ -669,13 +660,11 @@ impl Renderer<'_> {
         // let timer = Instant::now();
         // #[cfg(feature = "performance_measurement")]
         // encoder.write_timestamp(&self.performance_query_set, 0);
-        println!("Creating encoder took: {:?}", first_timer.elapsed());
 
         let output = self.surface.get_current_texture()?;
         let output_texture_view = output
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
-        println!("Getting output texture took: {:?}", first_timer.elapsed());
 
         let depth_texture =
             create_and_depth_texture(&self.device, (self.physical_size.0, self.physical_size.1));
@@ -689,8 +678,6 @@ impl Renderer<'_> {
 
             let render_pass =
                 create_render_pass(&mut encoder, &output_texture_view, &depth_texture_view);
-
-            println!("Creating pass took: {:?}", first_timer.elapsed());
 
             let shape_ids_to_stencil_references = HashMap::<usize, u32>::new();
             let current_pipeline = Pipeline::None;
@@ -756,7 +743,6 @@ impl Renderer<'_> {
                             }
                         }
                         DrawCommand::Image(image) => {
-                            println!("Image ID: {}", shape_id);
                             if let Some(clip_to_shape) = image.clip_to_shape {
                                 let parent_stencil =
                                     *stencil_references.get(&clip_to_shape).unwrap_or(&0);
@@ -825,7 +811,6 @@ impl Renderer<'_> {
                 },
                 &mut data,
             );
-            println!("Walking the tree took: {:?}", first_timer.elapsed());
 
             // println!("{}", self.text_instances.len());
             // TODO: cache the text rendering
@@ -872,7 +857,6 @@ impl Renderer<'_> {
 
         self.queue.submit(std::iter::once(encoder.finish()));
         output.present();
-        println!("Queue submit took: {:?}", first_timer.elapsed());
 
         #[cfg(feature = "performance_measurement")]
         {
@@ -910,8 +894,6 @@ impl Renderer<'_> {
 
         // self.depth_stencil_texture_viewer.save_depth_stencil_texture(&self.device);
         // self.depth_stencil_texture_viewer.print_texture_data_at_pixel(112, 40);
-
-        println!("Total time spent {:?}", first_timer.elapsed());
         // println!("Render method took: {:?}", timer.elapsed());
 
         Ok(())

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -70,16 +70,16 @@ use easy_tree::rayon::iter::ParallelIterator;
 
 pub type MathRect = lyon::math::Box2D;
 
+use crate::image_draw_data::ImageDrawData;
 use crate::pipeline::{
     create_and_depth_texture, create_depth_stencil_state_for_text, create_pipeline,
     create_render_pass, create_texture_pipeline, render_buffer_to_texture2, PipelineType, Uniforms,
 };
+use crate::shape::{Shape, ShapeDrawData};
 use crate::util::to_logical;
 use ahash::{HashMap, HashMapExt};
 use glyphon::{fontdb, Resolution};
 use log::warn;
-use crate::image_draw_data::ImageDrawData;
-use crate::shape::{Shape, ShapeDrawData};
 
 use crate::text::{TextDrawData, TextLayout, TextRendererWrapper};
 use crate::FontFamily;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -77,7 +77,7 @@ use crate::pipeline::{
 use crate::util::to_logical;
 use ahash::{HashMap, HashMapExt};
 use glyphon::{fontdb, Resolution};
-
+use log::warn;
 use crate::image_draw_data::ImageDrawData;
 use crate::shape::{Shape, ShapeDrawData};
 
@@ -738,7 +738,7 @@ impl Renderer<'_> {
                                     stencil_references.insert(shape_id, 1);
                                 }
                             } else {
-                                println!("Missing vertex or index buffer for shape {}", shape_id);
+                                warn!("Missing vertex or index buffer for shape {}", shape_id);
                             }
                         }
                         DrawCommand::Image(image) => {
@@ -798,7 +798,7 @@ impl Renderer<'_> {
                                     this_shape_stencil,
                                 );
                             } else {
-                                println!("No vertex or index buffer found for shape {}", shape_id);
+                                warn!("No vertex or index buffer found for shape {}", shape_id);
                                 // TODO: no vertex or index buffer found - it is an error,
                                 //  so probably should panic
                             }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -65,7 +65,6 @@
 //! ```
 
 use std::sync::Arc;
-use std::time::Instant;
 
 use easy_tree::rayon::iter::ParallelIterator;
 


### PR DESCRIPTION
This PR removes unnecessary printlns that were printing how long it took to render a frame. It also replaces printlns used to print warnings with `log::warn!`