### PR TITLE
feat: introduce text buffer id to keep track between buffers and their clips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "grafo"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafo"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 description = "A GPU-accelerated rendering library for Rust"
 keywords = ["rendering", "vector_graphics", "gui", "graphics", "image"]

--- a/examples/fonts.rs
+++ b/examples/fonts.rs
@@ -79,6 +79,7 @@ pub fn main() {
                     text_layout,
                     FontFamily::SansSerif,
                     Some(first_text_background_id),
+                    1
                 );
 
                 // Second text instance
@@ -110,6 +111,7 @@ pub fn main() {
                     text_layout2,
                     FontFamily::SansSerif,
                     Some(second_text_background_id),
+                    2
                 );
 
                 // Example with font loaded from file
@@ -141,6 +143,7 @@ pub fn main() {
                     text_layout3,
                     FontFamily::Name("Roboto"),
                     Some(third_text_background_id),
+                    3
                 );
 
                 // Example with system font
@@ -172,6 +175,7 @@ pub fn main() {
                     text_layout4,
                     FontFamily::Name("Papyrus"),
                     Some(fourth_text_background_id),
+                    4
                 );
 
                 let timer = Instant::now();

--- a/examples/fonts.rs
+++ b/examples/fonts.rs
@@ -79,7 +79,6 @@ pub fn main() {
                     text_layout,
                     FontFamily::SansSerif,
                     Some(first_text_background_id),
-                    1
                 );
 
                 // Second text instance
@@ -111,7 +110,6 @@ pub fn main() {
                     text_layout2,
                     FontFamily::SansSerif,
                     Some(second_text_background_id),
-                    2
                 );
 
                 // Example with font loaded from file
@@ -143,7 +141,6 @@ pub fn main() {
                     text_layout3,
                     FontFamily::Name("Roboto"),
                     Some(third_text_background_id),
-                    3
                 );
 
                 // Example with system font
@@ -175,7 +172,6 @@ pub fn main() {
                     text_layout4,
                     FontFamily::Name("Papyrus"),
                     Some(fourth_text_background_id),
-                    4
                 );
 
                 let timer = Instant::now();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -675,12 +675,23 @@ impl Renderer<'_> {
         self.text_buffer_ids_to_clips.insert(buffer_id, clip_to_shape.unwrap_or(0));
     }
 
-    /// [Renderer::add_text] lays out, shapes and styles the text. This method, on the other hand,
-    /// only adds the text buffer to the draw queue. This is useful when you want to use the text
-    /// buffer somewhere else, for example to detect clicks on the text.
+    /// This method  adds the text buffer to the draw queue. This is useful when you want to use
+    /// the text buffer somewhere else, for example to detect clicks on the text.
+    ///
+    /// # Parameters
+    ///
+    /// - `text_buffer`: Text buffer to be rendered.
+    /// - `area`: Where to render the text.
+    /// - `fallback_color`: Color used as a fallback color.
+    /// - `vertical_offset`: Vertical offset from the top of the canvas where to start rendering the text.
+    /// - `text_buffer_id`: Unique identifier for the text buffer. This value is used to map the text
+    ///     buffer to the clip shape. NOTE! This value should match the same value set as buffer's
+    ///     attr's metadata.
+    /// - `clip_to_shape`: Optional index of a shape to which this text should be clipped.
     ///
     /// # NOTE
-    /// What other methods accepts as clip_to_shape should be stored in the Buffer's attrs, otherwise it won't be rendered correctly.
+    /// It is very important to set the same value for `text_buffer_id` and the metadata of the buffer,
+    /// otherwise the text won't be rendered.
     pub fn add_text_buffer(
         &mut self,
         text_buffer: &glyphon::Buffer,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -635,9 +635,8 @@ impl Renderer<'_> {
         layout: impl Into<TextLayout>,
         font_family: FontFamily,
         clip_to_shape: Option<usize>,
-        text_id: usize,
     ) {
-        self.add_text_internal(text, layout, font_family, clip_to_shape, None, text_id)
+        self.add_text_internal(text, layout, font_family, clip_to_shape, None,)
     }
 
     /// Same as [Renderer::add_text], but allows to use a custom font system
@@ -648,9 +647,8 @@ impl Renderer<'_> {
         font_family: FontFamily,
         clip_to_shape: Option<usize>,
         font_system: &mut FontSystem,
-        text_id: usize,
     ) {
-        self.add_text_internal(text, layout, font_family, clip_to_shape, Some(font_system), text_id)
+        self.add_text_internal(text, layout, font_family, clip_to_shape, Some(font_system))
     }
 
     fn add_text_internal(
@@ -660,9 +658,10 @@ impl Renderer<'_> {
         font_family: FontFamily,
         clip_to_shape: Option<usize>,
         font_system: Option<&mut FontSystem>,
-        buffer_id: usize,
     ) {
         let font_system = font_system.unwrap_or(&mut self.font_system);
+
+        let buffer_id = self.text_instances.len();
 
         self.text_instances.push(TextDrawData::new(
             text,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -636,7 +636,7 @@ impl Renderer<'_> {
         font_family: FontFamily,
         clip_to_shape: Option<usize>,
     ) {
-        self.add_text_internal(text, layout, font_family, clip_to_shape, None,)
+        self.add_text_internal(text, layout, font_family, clip_to_shape, None)
     }
 
     /// Same as [Renderer::add_text], but allows to use a custom font system
@@ -672,7 +672,8 @@ impl Renderer<'_> {
             font_family,
             &mut self.buffers_pool_manager,
         ));
-        self.text_buffer_ids_to_clips.insert(buffer_id, clip_to_shape.unwrap_or(0));
+        self.text_buffer_ids_to_clips
+            .insert(buffer_id, clip_to_shape.unwrap_or(0));
     }
 
     /// This method  adds the text buffer to the draw queue. This is useful when you want to use
@@ -715,7 +716,8 @@ impl Renderer<'_> {
             fallback_color,
             vertical_offset,
         ));
-        self.text_buffer_ids_to_clips.insert(text_buffer_id, clip_to_shape.unwrap_or(0));
+        self.text_buffer_ids_to_clips
+            .insert(text_buffer_id, clip_to_shape.unwrap_or(0));
     }
 
     /// Renders all items currently in the draw queue.
@@ -972,7 +974,11 @@ impl Renderer<'_> {
                     swash_cache,
                     |buffer_id| {
                         // TODO: print warning if the buffer is not found
-                        let clip_to_shape = self.text_buffer_ids_to_clips.get(&buffer_id).copied().unwrap_or(0);
+                        let clip_to_shape = self
+                            .text_buffer_ids_to_clips
+                            .get(&buffer_id)
+                            .copied()
+                            .unwrap_or(0);
                         depth(clip_to_shape, draw_tree_size)
                     },
                 )

--- a/src/text.rs
+++ b/src/text.rs
@@ -271,13 +271,6 @@ impl TextDrawData {
         let top = self.top;
 
         let bounds = TextBounds {
-            left: i32::MIN,
-            top: i32::MIN,
-            right: i32::MAX,
-            bottom: i32::MAX,
-        };
-
-        let bounds = TextBounds {
             left: (area.min.x * scale_factor) as i32,
             top: (area.min.y * scale_factor) as i32,
             right: (area.max.x * scale_factor) as i32,

--- a/src/text.rs
+++ b/src/text.rs
@@ -34,7 +34,6 @@ use crate::Color;
 use glyphon::cosmic_text::Align;
 use glyphon::{Attrs, Family, FontSystem, Metrics, Shaping, TextAtlas, TextRenderer};
 use glyphon::{Buffer as TextBuffer, Color as TextColor, TextArea, TextBounds};
-use glyphon::cosmic_text::ttf_parser::opentype_layout::ClassDefinition;
 use wgpu::{Device, MultisampleState};
 
 /// Specifies the alignment of text within its layout area.
@@ -192,9 +191,7 @@ impl TextDrawData {
         buffer.set_text(
             font_system,
             text,
-            Attrs::new()
-                .family(font_family)
-                .metadata(buffer_id),
+            Attrs::new().family(font_family).metadata(buffer_id),
             Shaping::Advanced,
         );
 


### PR DESCRIPTION
This PR introduces a new argument to all add_text_buffer method: a buffer id that is used to properly clip the text buffer later.