### PR TITLE
feat: shape buffer batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "grafo"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafo"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "A GPU-accelerated rendering library for Rust"
 keywords = ["rendering", "vector_graphics", "gui", "graphics", "image"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -68,13 +68,33 @@ impl<'a> ApplicationHandler for App<'a> {
                 renderer.resize(new_size);
                 window.request_redraw();
             }
-            WindowEvent::RedrawRequested => match renderer.render() {
-                Ok(_) => {
-                    renderer.clear_draw_queue();
+            WindowEvent::RedrawRequested => {
+                // Define a simple rectangle shape
+                let rect = Shape::rect(
+                    [(100.0, 100.0), (300.0, 200.0)],
+                    Color::rgb(0, 128, 255),        // Blue fill
+                    Stroke::new(2.0, Color::BLACK), // Black stroke with width 2.0
+                );
+                println!("Adding shape to renderer");
+                renderer.add_shape(rect, None, (0.0, 0.0), None);
+
+                let rect = Shape::rect(
+                    [(500.0, 100.0), (600.0, 200.0)],
+                    Color::rgb(0, 128, 0),        // Blue fill
+                    Stroke::new(2.0, Color::BLACK), // Black stroke with width 2.0
+                );
+                println!("Adding shape to renderer");
+                renderer.add_shape(rect, None, (0.0, 0.0), None);
+
+                match renderer.render() {
+                    Ok(_) => {
+                        println!("Hehe");
+                        renderer.clear_draw_queue();
+                    }
+                    Err(wgpu::SurfaceError::Lost) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::OutOfMemory) => event_loop.exit(),
+                    Err(e) => eprintln!("{e:?}"),
                 }
-                Err(wgpu::SurfaceError::Lost) => renderer.resize(renderer.size()),
-                Err(wgpu::SurfaceError::OutOfMemory) => event_loop.exit(),
-                Err(e) => eprintln!("{e:?}"),
             },
             _ => {}
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -75,27 +75,24 @@ impl<'a> ApplicationHandler for App<'a> {
                     Color::rgb(0, 128, 255),        // Blue fill
                     Stroke::new(2.0, Color::BLACK), // Black stroke with width 2.0
                 );
-                println!("Adding shape to renderer");
                 renderer.add_shape(rect, None, (0.0, 0.0), None);
 
                 let rect = Shape::rect(
                     [(500.0, 100.0), (600.0, 200.0)],
-                    Color::rgb(0, 128, 0),        // Blue fill
+                    Color::rgb(0, 128, 0),          // Blue fill
                     Stroke::new(2.0, Color::BLACK), // Black stroke with width 2.0
                 );
-                println!("Adding shape to renderer");
                 renderer.add_shape(rect, None, (0.0, 0.0), None);
 
                 match renderer.render() {
                     Ok(_) => {
-                        println!("Hehe");
                         renderer.clear_draw_queue();
                     }
                     Err(wgpu::SurfaceError::Lost) => renderer.resize(renderer.size()),
                     Err(wgpu::SurfaceError::OutOfMemory) => event_loop.exit(),
                     Err(e) => eprintln!("{e:?}"),
                 }
-            },
+            }
             _ => {}
         }
     }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -98,7 +98,7 @@ impl<'a> ApplicationHandler for App<'a> {
                         (0.0, 0.0),
                         (window_size.width as f32, window_size.height as f32),
                     ],
-                    Color::rgb(255, 255, 255),
+                    Color::rgb(255, 255, 200),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -420,7 +420,7 @@ pub fn render_buffer_range_to_texture(
     vertex_buffer: &wgpu::Buffer,
     index_buffer: &wgpu::Buffer,
     _vertex_range: (usize, usize), // (start_vertex, vertex_count) - not needed with current approach
-    index_range: (usize, usize),  // (start_index, index_count)
+    index_range: (usize, usize),   // (start_index, index_count)
     incrementing_pass: &mut RenderPass<'_>,
     parent_stencil_reference: u32,
 ) {
@@ -429,13 +429,13 @@ pub fn render_buffer_range_to_texture(
     // Use the full buffers but specify the vertex base offset in draw_indexed
     incrementing_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
     incrementing_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-    
+
     // The indices in the aggregated buffer are already offset, so we need to:
     // 1. Use the correct index range
     // 2. Set the vertex base to 0 since we're using the full vertex buffer
     let index_start = index_range.0 as u32;
     let index_end = (index_range.0 + index_range.1) as u32;
-    
+
     incrementing_pass.draw_indexed(index_start..index_end, 0, 0..1);
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -439,21 +439,6 @@ pub fn render_buffer_range_to_texture(
     incrementing_pass.draw_indexed(index_start..index_end, 0, 0..1);
 }
 
-// Renders buffer to texture and increments stencil value where the buffer is drawn.
-pub fn render_buffer_to_texture2(
-    vertex_buffer: &wgpu::Buffer,
-    index_buffer: &wgpu::Buffer,
-    num_indices: u32,
-    incrementing_pass: &mut RenderPass<'_>,
-    parent_stencil_reference: u32,
-) {
-    incrementing_pass.set_stencil_reference(parent_stencil_reference);
-
-    incrementing_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-    incrementing_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-    incrementing_pass.draw_indexed(0..num_indices, 0, 0..1);
-}
-
 pub fn create_texture_pipeline(
     device: &wgpu::Device,
     config: &wgpu::SurfaceConfiguration,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -419,24 +419,24 @@ pub fn create_and_depth_texture(device: &Device, size: (u32, u32)) -> Texture {
 pub fn render_buffer_range_to_texture(
     vertex_buffer: &wgpu::Buffer,
     index_buffer: &wgpu::Buffer,
-    vertex_range: (usize, usize), // (start_vertex, vertex_count)
+    _vertex_range: (usize, usize), // (start_vertex, vertex_count) - not needed with current approach
     index_range: (usize, usize),  // (start_index, index_count)
     incrementing_pass: &mut RenderPass<'_>,
     parent_stencil_reference: u32,
 ) {
-    use std::mem::size_of;
-    
     incrementing_pass.set_stencil_reference(parent_stencil_reference);
 
-    let vertex_start_bytes = (vertex_range.0 * size_of::<crate::vertex::CustomVertex>()) as u64;
-    let vertex_size_bytes = (vertex_range.1 * size_of::<crate::vertex::CustomVertex>()) as u64;
+    // Use the full buffers but specify the vertex base offset in draw_indexed
+    incrementing_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+    incrementing_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint16);
     
-    let index_start_bytes = (index_range.0 * size_of::<u16>()) as u64;
-    let index_size_bytes = (index_range.1 * size_of::<u16>()) as u64;
-
-    incrementing_pass.set_vertex_buffer(0, vertex_buffer.slice(vertex_start_bytes..vertex_start_bytes + vertex_size_bytes));
-    incrementing_pass.set_index_buffer(index_buffer.slice(index_start_bytes..index_start_bytes + index_size_bytes), wgpu::IndexFormat::Uint16);
-    incrementing_pass.draw_indexed(0..index_range.1 as u32, 0, 0..1);
+    // The indices in the aggregated buffer are already offset, so we need to:
+    // 1. Use the correct index range
+    // 2. Set the vertex base to 0 since we're using the full vertex buffer
+    let index_start = index_range.0 as u32;
+    let index_end = (index_range.0 + index_range.1) as u32;
+    
+    incrementing_pass.draw_indexed(index_start..index_end, 0, 0..1);
 }
 
 // Renders buffer to texture and increments stencil value where the buffer is drawn.

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -905,6 +905,7 @@ impl<'a> Renderer<'a> {
         let draw_tree_size = self.draw_tree.len();
         let iter = self.draw_tree.iter_mut();
 
+        let time_start = std::time::Instant::now();
         iter.for_each(|draw_command| match draw_command.1 {
             DrawCommand::Shape(ref mut shape) => {
                 let depth = depth(draw_command.0, draw_tree_size);
@@ -920,6 +921,11 @@ impl<'a> Renderer<'a> {
                 );
             }
         });
+        let time_tessellation = time_start.elapsed();
+        println!(
+            "Tessellation and buffer preparation took: {:.2} ms",
+            time_tessellation.as_secs_f64() * 1000.0
+        );
 
         let mut encoder = self
             .device
@@ -1461,6 +1467,15 @@ impl<'a> Renderer<'a> {
                 height: new_physical_size.1,
             },
         );
+    }
+
+    pub fn set_vsync(&mut self, vsync: bool) {
+        self.config.present_mode = if vsync {
+            wgpu::PresentMode::Fifo
+        } else {
+            wgpu::PresentMode::Immediate
+        };
+        self.surface.configure(&self.device, &self.config);
     }
 
     /// Loads fonts from the specified sources.

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -37,7 +37,6 @@
 //!     .build();
 //! ```
 
-use std::rc::Rc;
 use crate::util::PoolManager;
 use crate::vertex::CustomVertex;
 use crate::{Color, Stroke};
@@ -46,6 +45,7 @@ use lyon::lyon_tessellation::{
 };
 use lyon::path::Winding;
 use lyon::tessellation::FillVertexConstructor;
+use std::rc::Rc;
 
 /// Represents a graphical shape, which can be either a custom path or a simple rectangle.
 ///
@@ -449,7 +449,7 @@ impl ShapeDrawData {
             cache_key,
             vertex_buffer_range: None,
             index_buffer_range: None,
-            is_empty: false
+            is_empty: false,
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use crate::cache::Cache;
 use crate::renderer::MathRect;
 use crate::vertex::CustomVertex;
 use lyon::geom::euclid::Point2D;
 use lyon::tessellation::VertexBuffers;
+use std::collections::HashMap;
 use wgpu::util::DeviceExt;
 use wgpu::{Buffer, BufferUsages};
 
@@ -49,7 +49,7 @@ impl BufferPool {
     pub(crate) fn get_buffer(&mut self, device: &wgpu::Device, size: usize) -> Buffer {
         if let Some(cache) = self.buffers.get_mut(&size) {
             if let Some(buffer) = cache.pop() {
-                return buffer;
+                buffer
             } else {
                 device.create_buffer(&wgpu::BufferDescriptor {
                     label: None,


### PR DESCRIPTION
This PR adds batching for rendered shapes - now instead of using a lot of small buffers for rendering shapes renderer uses one large buffer. It significantly speeds up rendering - prior to this change buffer preparation used to take half if the rendering time, and now it is reduced to ~10% of rendering time.