### PR TITLE
feat: front-to-back rendering

### DIFF
--- a/grafo-test-scenes/src/shaders.rs
+++ b/grafo-test-scenes/src/shaders.rs
@@ -64,3 +64,26 @@ pub struct BlurParams {
     pub _pad: f32,
     pub tex_size: [f32; 2],
 }
+
+/// Simple opacity (tint) effect — multiplies alpha by a uniform factor.
+/// This is a single-pass effect. Useful for testing group composite depth.
+pub const OPACITY_WGSL: &str = r#"
+struct OpacityParams {
+    opacity: f32,
+}
+@group(1) @binding(0) var<uniform> params: OpacityParams;
+
+@fragment
+fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    let c = textureSample(t_input, s_input, uv);
+    return vec4<f32>(c.rgb * params.opacity, c.a * params.opacity);
+}
+"#;
+
+/// Parameters for the opacity effect.
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+#[allow(dead_code)]
+pub struct OpacityParams {
+    pub opacity: f32,
+}

--- a/grafo-test-scenes/src/shaders.rs
+++ b/grafo-test-scenes/src/shaders.rs
@@ -65,7 +65,7 @@ pub struct BlurParams {
     pub tex_size: [f32; 2],
 }
 
-/// Simple opacity (tint) effect — multiplies alpha by a uniform factor.
+/// Simple opacity (tint) effect — multiplies RGBA by a uniform factor.
 /// This is a single-pass effect. Useful for testing group composite depth.
 pub const OPACITY_WGSL: &str = r#"
 struct OpacityParams {

--- a/src/renderer/metrics.rs
+++ b/src/renderer/metrics.rs
@@ -16,12 +16,22 @@ pub struct PipelineSwitchCounts {
     pub to_stencil_decrement: u32,
     /// Number of switches to the leaf-draw pipeline.
     pub to_leaf_draw: u32,
+    /// Number of switches to the opaque-leaf-draw pipeline.
+    pub to_opaque_leaf_draw: u32,
+    /// Number of switches to the opaque-fringe-draw pipeline.
+    pub to_opaque_fringe_draw: u32,
     /// Number of switches to the composite (effect) pipeline, which resets tracking.
     pub to_composite: u32,
     /// Total GPU pipeline switches (`set_pipeline` calls).
     pub total_switches: u32,
     /// Number of parent shapes clipped via scissor rect instead of stencil.
     pub scissor_clips: u32,
+    /// Number of draw calls issued in the opaque phase.
+    pub opaque_draw_calls: u32,
+    /// Number of draw calls issued in the transparent phase.
+    pub transparent_draw_calls: u32,
+    /// Number of segments that skipped the opaque phase (no opaque shapes or unbalanced).
+    pub opaque_phase_skipped_segments: u32,
 }
 
 impl PipelineSwitchCounts {
@@ -30,9 +40,14 @@ impl PipelineSwitchCounts {
         self.to_stencil_increment += other.to_stencil_increment;
         self.to_stencil_decrement += other.to_stencil_decrement;
         self.to_leaf_draw += other.to_leaf_draw;
+        self.to_opaque_leaf_draw += other.to_opaque_leaf_draw;
+        self.to_opaque_fringe_draw += other.to_opaque_fringe_draw;
         self.to_composite += other.to_composite;
         self.total_switches += other.total_switches;
         self.scissor_clips += other.scissor_clips;
+        self.opaque_draw_calls += other.opaque_draw_calls;
+        self.transparent_draw_calls += other.transparent_draw_calls;
+        self.opaque_phase_skipped_segments += other.opaque_phase_skipped_segments;
     }
 }
 

--- a/src/renderer/rendering.rs
+++ b/src/renderer/rendering.rs
@@ -210,7 +210,6 @@ impl<'a> Renderer<'a> {
                         #[cfg(feature = "render_metrics")]
                         &mut frame_pipeline_counts,
                     );
-                    drop(bg_depth_ctx);
                     Some(behind_tex)
                 } else {
                     None
@@ -303,7 +302,6 @@ impl<'a> Renderer<'a> {
                     #[cfg(feature = "render_metrics")]
                     &mut frame_pipeline_counts,
                 );
-                drop(sub_depth_ctx);
 
                 effect_output_textures.append(&mut backdrop_work_textures);
                 if let Some(behind_tex) = behind_texture {

--- a/src/renderer/rendering.rs
+++ b/src/renderer/rendering.rs
@@ -37,8 +37,6 @@ impl<'a> Renderer<'a> {
         }
         if has_backdrop_effects {
             self.ensure_backdrop_snapshot_texture();
-            self.ensure_stencil_only_pipeline();
-            self.ensure_backdrop_color_pipeline();
         }
 
         // O1: Ensure depth/stencil texture exists (lazy init on first frame)
@@ -56,11 +54,13 @@ impl<'a> Renderer<'a> {
             });
 
         let pipelines = crate::renderer::types::Pipelines {
-            and_pipeline: &self.and_pipeline,
             and_bind_group: &self.and_bind_group,
             decrementing_pipeline: &self.decrementing_pipeline,
             decrementing_bind_group: &self.decrementing_bind_group,
-            leaf_draw_pipeline: &self.leaf_draw_pipeline,
+            stencil_only_pipeline: self.stencil_only_pipeline.as_ref().unwrap(),
+            transparent_leaf_draw_pipeline: &self.transparent_leaf_draw_pipeline,
+            opaque_leaf_draw_pipeline: &self.opaque_leaf_draw_pipeline,
+            opaque_fringe_draw_pipeline: &self.opaque_fringe_draw_pipeline,
             shape_texture_bind_group_layout_background: &self
                 .shape_texture_bind_group_layout_background,
             shape_texture_bind_group_layout_foreground: &self
@@ -88,6 +88,13 @@ impl<'a> Renderer<'a> {
             aggregated_instance_color_buffer: self.aggregated_instance_color_buffer.as_ref(),
             aggregated_instance_metadata_buffer: self.aggregated_instance_metadata_buffer.as_ref(),
         };
+
+        // Reset composite depth slot allocator once per frame so that all
+        // render_segments calls (behind-group, subtree, main scene) receive
+        // unique, non-overlapping slots.  Resetting per-call would let later
+        // queue.write_buffer calls overwrite earlier slot values before the
+        // single queue.submit executes.
+        self.composite_depth_slot_allocator.reset();
 
         if has_group_effects {
             effect_node_ids.clear();
@@ -160,6 +167,25 @@ impl<'a> Renderer<'a> {
                         Some(node_id),
                         &mut traversal_scratch,
                     );
+                    // Build composite depth context for behind-group render
+                    // so nested effect composites can bind @group(1).
+                    let mut bg_depth_ctx = match (
+                        self.composite_depth_buffer.as_mut(),
+                        self.composite_depth_bind_group.as_mut(),
+                        self.composite_depth_bgl.as_ref(),
+                    ) {
+                        (Some(buffer), Some(bind_group), Some(bgl)) => {
+                            Some(crate::renderer::types::CompositeDepthCtx {
+                                queue: &self.queue,
+                                buffer,
+                                bind_group,
+                                bgl,
+                                device: &self.device,
+                                slot_allocator: &mut self.composite_depth_slot_allocator,
+                            })
+                        }
+                        _ => None,
+                    };
                     render_segments(
                         &mut self.draw_tree,
                         &mut encoder,
@@ -173,6 +199,7 @@ impl<'a> Renderer<'a> {
                         &pipelines,
                         &buffers,
                         self.composite_pipeline.as_ref(),
+                        bg_depth_ctx.as_mut(),
                         None,
                         &mut backdrop_work_textures,
                         &mut stencil_stack,
@@ -183,6 +210,7 @@ impl<'a> Renderer<'a> {
                         #[cfg(feature = "render_metrics")]
                         &mut frame_pipeline_counts,
                     );
+                    drop(bg_depth_ctx);
                     Some(behind_tex)
                 } else {
                     None
@@ -215,7 +243,6 @@ impl<'a> Renderer<'a> {
                         composite_bgl: self.composite_bgl.as_ref().unwrap(),
                         effect_sampler: self.effect_sampler.as_ref().unwrap(),
                         stencil_only_pipeline: self.stencil_only_pipeline.as_ref().unwrap(),
-                        backdrop_color_pipeline: self.backdrop_color_pipeline.as_ref().unwrap(),
                         device: &self.device,
                         config_format: self.config.format,
                         backdrop_snapshot_texture: self.backdrop_snapshot_texture.as_ref().unwrap(),
@@ -233,6 +260,25 @@ impl<'a> Renderer<'a> {
                     }
                 });
 
+                // Build composite depth context for subtree render
+                // so nested effect composites can bind @group(1).
+                let mut sub_depth_ctx = match (
+                    self.composite_depth_buffer.as_mut(),
+                    self.composite_depth_bind_group.as_mut(),
+                    self.composite_depth_bgl.as_ref(),
+                ) {
+                    (Some(buffer), Some(bind_group), Some(bgl)) => {
+                        Some(crate::renderer::types::CompositeDepthCtx {
+                            queue: &self.queue,
+                            buffer,
+                            bind_group,
+                            bgl,
+                            device: &self.device,
+                            slot_allocator: &mut self.composite_depth_slot_allocator,
+                        })
+                    }
+                    _ => None,
+                };
                 render_segments(
                     &mut self.draw_tree,
                     &mut encoder,
@@ -246,6 +292,7 @@ impl<'a> Renderer<'a> {
                     &pipelines,
                     &buffers,
                     self.composite_pipeline.as_ref(),
+                    sub_depth_ctx.as_mut(),
                     backdrop_ctx_opt.as_ref(),
                     &mut backdrop_work_textures,
                     &mut stencil_stack,
@@ -256,6 +303,7 @@ impl<'a> Renderer<'a> {
                     #[cfg(feature = "render_metrics")]
                     &mut frame_pipeline_counts,
                 );
+                drop(sub_depth_ctx);
 
                 effect_output_textures.append(&mut backdrop_work_textures);
                 if let Some(behind_tex) = behind_texture {
@@ -321,7 +369,6 @@ impl<'a> Renderer<'a> {
                     composite_bgl: self.composite_bgl.as_ref().unwrap(),
                     effect_sampler: self.effect_sampler.as_ref().unwrap(),
                     stencil_only_pipeline: self.stencil_only_pipeline.as_ref().unwrap(),
-                    backdrop_color_pipeline: self.backdrop_color_pipeline.as_ref().unwrap(),
                     device: &self.device,
                     config_format: self.config.format,
                     backdrop_snapshot_texture: self.backdrop_snapshot_texture.as_ref().unwrap(),
@@ -337,6 +384,25 @@ impl<'a> Renderer<'a> {
                 None
             };
 
+            // Build composite depth context if resources are available.
+            let mut composite_depth_ctx = match (
+                self.composite_depth_buffer.as_mut(),
+                self.composite_depth_bind_group.as_mut(),
+                self.composite_depth_bgl.as_ref(),
+            ) {
+                (Some(buffer), Some(bind_group), Some(bgl)) => {
+                    Some(crate::renderer::types::CompositeDepthCtx {
+                        queue: &self.queue,
+                        buffer,
+                        bind_group,
+                        bgl,
+                        device: &self.device,
+                        slot_allocator: &mut self.composite_depth_slot_allocator,
+                    })
+                }
+                _ => None,
+            };
+
             render_segments(
                 &mut self.draw_tree,
                 &mut encoder,
@@ -350,6 +416,7 @@ impl<'a> Renderer<'a> {
                 &pipelines,
                 &buffers,
                 self.composite_pipeline.as_ref(),
+                composite_depth_ctx.as_mut(),
                 backdrop_ctx_opt.as_ref(),
                 &mut backdrop_work_textures,
                 &mut stencil_stack,

--- a/src/renderer/surface.rs
+++ b/src/renderer/surface.rs
@@ -75,6 +75,8 @@ impl<'a> Renderer<'a> {
         self.msaa_sample_count = validated;
         self.recreate_pipelines();
         self.recreate_msaa_texture();
+        // Depth-stencil texture sample count must match pipeline multisample.count.
+        self.recreate_depth_stencil_texture();
     }
 
     pub(super) fn validate_sample_count_static(requested: u32) -> u32 {
@@ -109,8 +111,6 @@ impl<'a> Renderer<'a> {
 
         self.backdrop_snapshot_texture = None;
         self.backdrop_snapshot_view = None;
-        self.stencil_only_pipeline = None;
-        self.backdrop_color_pipeline = None;
 
         self.offscreen_texture_pool.trim(
             self.physical_size.0,

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -141,7 +141,7 @@ pub(super) enum Pipeline {
 /// A deferred opaque draw, collected during the opaque phase and flushed
 /// (sorted front-to-back) at scope exit for maximum early-Z benefit.
 pub(super) struct DeferredOpaqueDraw {
-    /// Traversal order stamp (lower = closer to camera). Used as sort key.
+    /// Traversal order stamp (higher = closer to camera). Used as sort key.
     pub traversal_order: u32,
     /// Stencil reference for this draw.
     pub stencil_ref: u32,


### PR DESCRIPTION
This PR changes rendering algorithm from back-to-front to front-to-back in order to reduce overdraw and increase performance on lower-end hardware, especially on tile-based hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opacity tint support and improved handling of semi-transparent content
  * Two-phase rendering (opaque then transparent) with AA fringe rendering for crisper edges
  * Per-composite depth management and traversal-order depth mapping for more accurate layering

* **Tests**
  * Added 6 rendering tests covering depth cull, behind-opaque transparency, fringe AA, mixed clipping, group composite depth, and transparent-only segments

* **Other**
  * Scene grid expanded to accommodate additional tiles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->