### PR TITLE
feat: add a warning when a shape can't be added to a draw queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "grafo"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "grafo-test-scenes"]
 
 [package]
 name = "grafo"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "A GPU-accelerated rendering library for Rust"
 keywords = ["rendering", "vector_graphics", "gui", "graphics", "image"]

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -156,7 +156,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(20.0, 20.0), (780.0, 580.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let bg_id = renderer.add_shape(bg, None, None);
+                let bg_id = renderer.add_shape(bg, None, None).unwrap();
                 renderer.set_shape_color(bg_id, Some(Color::rgb(245, 245, 250)));
 
                 // Colorful rectangles that will be visible through the panel
@@ -164,28 +164,28 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(60.0, 80.0), (260.0, 260.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
-                let r1_id = renderer.add_shape(r1, Some(bg_id), None);
+                let r1_id = renderer.add_shape(r1, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)));
 
                 let r2 = Shape::rect(
                     [(180.0, 160.0), (420.0, 380.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
-                let r2_id = renderer.add_shape(r2, Some(bg_id), None);
+                let r2_id = renderer.add_shape(r2, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)));
 
                 let r3 = Shape::rect(
                     [(340.0, 100.0), (560.0, 300.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
-                let r3_id = renderer.add_shape(r3, Some(bg_id), None);
+                let r3_id = renderer.add_shape(r3, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)));
 
                 let r4 = Shape::rect(
                     [(100.0, 350.0), (700.0, 540.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
-                let r4_id = renderer.add_shape(r4, Some(bg_id), None);
+                let r4_id = renderer.add_shape(r4, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)));
 
                 // ── Frosted-glass panel with backdrop blur ───────────────
@@ -195,7 +195,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(120.0, 120.0), (520.0, 460.0)],
                     Stroke::new(2.0, Color::rgb(100, 100, 100)),
                 );
-                let panel_id = renderer.add_shape(panel, None, None);
+                let panel_id = renderer.add_shape(panel, None, None).unwrap();
                 // Semi-transparent white so the blurred background shows through
                 renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 100)));
 
@@ -205,7 +205,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(100.0),
                     Stroke::new(1.0, Color::rgb(80, 80, 80)),
                 );
-                let content_id = renderer.add_shape(panel_content, Some(panel_id), None);
+                let content_id = renderer
+                    .add_shape(panel_content, Some(panel_id), None)
+                    .unwrap();
                 renderer.set_shape_color(content_id, Some(Color::rgba(200, 220, 255, 120)));
 
                 let blur_params = BlurParams {
@@ -226,7 +228,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(560.0, 200.0), (740.0, 400.0)],
                     Stroke::new(2.0, Color::rgb(80, 80, 80)),
                 );
-                let panel2_id = renderer.add_shape(panel2, None, None);
+                let panel2_id = renderer.add_shape(panel2, None, None).unwrap();
                 renderer.set_shape_color(panel2_id, Some(Color::rgba(200, 220, 255, 120)));
 
                 let blur_params2 = BlurParams {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -40,7 +40,7 @@ impl<'a> ApplicationHandler for App<'a> {
             [(100.0, 100.0), (300.0, 200.0)],
             Stroke::new(2.0, Color::BLACK),
         );
-        let id = renderer.add_shape(rect, None, None);
+        let id = renderer.add_shape(rect, None, None).unwrap();
         renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
 
         self.window = Some(window);
@@ -75,14 +75,14 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(100.0, 100.0), (300.0, 200.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let id = renderer.add_shape(rect, None, None);
+                let id = renderer.add_shape(rect, None, None).unwrap();
                 renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
 
                 let rect = Shape::rect(
                     [(500.0, 100.0), (600.0, 200.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let id2 = renderer.add_shape(rect, None, None);
+                let id2 = renderer.add_shape(rect, None, None).unwrap();
                 renderer.set_shape_color(id2, Some(Color::rgb(0, 128, 0)));
 
                 match renderer.render() {

--- a/examples/bench_render_loop.rs
+++ b/examples/bench_render_loop.rs
@@ -121,7 +121,9 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
     let mut total_shapes = 0;
 
     for c in 0..CONTAINERS {
-        let container_id = renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_CONTAINER, None);
+        let container_id = renderer
+            .add_cached_shape_to_the_render_queue(CACHE_KEY_CONTAINER, None)
+            .unwrap();
         renderer.set_shape_color(
             container_id,
             Some(container_colors[c % container_colors.len()]),
@@ -131,8 +133,9 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
         total_shapes += 1;
 
         for r in 0..ROWS_PER_CONTAINER {
-            let row_id =
-                renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_ROW, Some(container_id));
+            let row_id = renderer
+                .add_cached_shape_to_the_render_queue(CACHE_KEY_ROW, Some(container_id))
+                .unwrap();
             renderer.set_shape_color(row_id, Some(Color::rgb(200, 200, 210)));
             let ry = 10.0 + r as f32 * 120.0;
             renderer
@@ -140,8 +143,9 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
             total_shapes += 1;
 
             for cell in 0..CELLS_PER_ROW {
-                let cell_id =
-                    renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_CELL, Some(row_id));
+                let cell_id = renderer
+                    .add_cached_shape_to_the_render_queue(CACHE_KEY_CELL, Some(row_id))
+                    .unwrap();
                 let brightness = (100u8).saturating_add((cell * 30) as u8);
                 renderer.set_shape_color(
                     cell_id,
@@ -157,14 +161,17 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
 
     // Sidebar with circles
     let sidebar_x = 10.0 + CONTAINERS as f32 * 250.0;
-    let sidebar_id = renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_SIDEBAR, None);
+    let sidebar_id = renderer
+        .add_cached_shape_to_the_render_queue(CACHE_KEY_SIDEBAR, None)
+        .unwrap();
     renderer.set_shape_color(sidebar_id, Some(Color::rgb(50, 50, 70)));
     renderer.set_shape_transform(sidebar_id, TransformInstance::translation(sidebar_x, 10.0));
     total_shapes += 1;
 
     for i in 0..CIRCLES_IN_SIDEBAR {
-        let circle_id =
-            renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_CIRCLE, Some(sidebar_id));
+        let circle_id = renderer
+            .add_cached_shape_to_the_render_queue(CACHE_KEY_CIRCLE, Some(sidebar_id))
+            .unwrap();
         renderer.set_shape_color(circle_id, Some(Color::rgb(220, 180, 50)));
         renderer.set_shape_transform(
             circle_id,
@@ -176,7 +183,9 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
     // Textured elements — 25 shapes with distinct textures, some overlapping
     // Laid out in a 5×5 grid starting below the containers, partially overlapping by 30px
     for i in 0..TEXTURED_ELEMENTS {
-        let tex_id = renderer.add_cached_shape_to_the_render_queue(CACHE_KEY_TEXTURED, None);
+        let tex_id = renderer
+            .add_cached_shape_to_the_render_queue(CACHE_KEY_TEXTURED, None)
+            .unwrap();
         renderer.set_shape_texture(tex_id, Some(TEXTURE_ID_BASE + i as u64));
         let col = i % 5;
         let row = i / 5;

--- a/examples/box_shadow.rs
+++ b/examples/box_shadow.rs
@@ -73,7 +73,7 @@ fn draw_card(
         BorderRadii::new(radius),
         Stroke::new(0.0, Color::TRANSPARENT),
     );
-    let card = renderer.add_shape(card_shape, None, None);
+    let card = renderer.add_shape(card_shape, None, None).unwrap();
     renderer.set_shape_color(card, Some(card_color));
 
     let params = BoxShadowParams {
@@ -244,7 +244,7 @@ impl<'a> ApplicationHandler for App<'a> {
                 // ── Scene background ─────────────────────────────────────
                 let scene_bg =
                     Shape::rect([(0.0, 0.0), (pw, ph)], Stroke::new(0.0, Color::TRANSPARENT));
-                let bg_id = renderer.add_shape(scene_bg, None, None);
+                let bg_id = renderer.add_shape(scene_bg, None, None).unwrap();
                 renderer.set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)));
 
                 let vp = (pw, ph);

--- a/examples/gaussian_blur.rs
+++ b/examples/gaussian_blur.rs
@@ -153,7 +153,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(30.0, 30.0), (770.0, 570.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let bg_id = renderer.add_shape(bg, None, None);
+                let bg_id = renderer.add_shape(bg, None, None).unwrap();
                 renderer.set_shape_color(bg_id, Some(Color::rgb(240, 240, 245)));
 
                 // ── Label text (just a thin rectangle as a visual marker) ─
@@ -161,7 +161,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(310.0, 200.0), (750.0, 230.0)],
                     Stroke::new(1.0, Color::BLACK),
                 );
-                let l = renderer.add_shape(label, Some(bg_id), None);
+                let l = renderer.add_shape(label, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(l, Some(Color::rgb(200, 200, 255)));
 
                 // ── Blurred group ────────────────────────────────────────
@@ -170,7 +170,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(80.0, 80.0), (500.0, 400.0)],
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
-                let group = renderer.add_shape(group_bg, None, None);
+                let group = renderer.add_shape(group_bg, None, None).unwrap();
                 renderer.set_shape_color(group, Some(Color::rgba(255, 100, 100, 100)));
 
                 // Child shapes inside the group
@@ -178,14 +178,14 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(100.0, 100.0), (300.0, 280.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
-                let c1 = renderer.add_shape(child1, Some(group), None);
+                let c1 = renderer.add_shape(child1, Some(group), None).unwrap();
                 renderer.set_shape_color(c1, Some(Color::rgb(50, 120, 255)));
 
                 let child2 = Shape::rect(
                     [(200.0, 180.0), (450.0, 360.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
-                let c2 = renderer.add_shape(child2, Some(group), None);
+                let c2 = renderer.add_shape(child2, Some(group), None).unwrap();
                 renderer.set_shape_color(c2, Some(Color::rgb(50, 220, 80)));
 
                 // Attach the blur effect with radius = 8 pixels
@@ -203,21 +203,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(80.0, 420.0), (500.0, 560.0)],
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
-                let sharp = renderer.add_shape(sharp_bg, None, None);
+                let sharp = renderer.add_shape(sharp_bg, None, None).unwrap();
                 renderer.set_shape_color(sharp, Some(Color::rgb(255, 100, 100)));
 
                 let sc1 = Shape::rect(
                     [(100.0, 430.0), (300.0, 550.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
-                let s1 = renderer.add_shape(sc1, Some(sharp), None);
+                let s1 = renderer.add_shape(sc1, Some(sharp), None).unwrap();
                 renderer.set_shape_color(s1, Some(Color::rgb(50, 120, 255)));
 
                 let sc2 = Shape::rect(
                     [(200.0, 440.0), (450.0, 550.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
-                let s2 = renderer.add_shape(sc2, Some(sharp), None);
+                let s2 = renderer.add_shape(sc2, Some(sharp), None).unwrap();
                 renderer.set_shape_color(s2, Some(Color::rgb(50, 220, 80)));
 
                 // ── Render ───────────────────────────────────────────────

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -102,7 +102,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(50.0, 50.0), (750.0, 550.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let bg_id = renderer.add_shape(bg, None, None);
+                let bg_id = renderer.add_shape(bg, None, None).unwrap();
                 renderer.set_shape_color(bg_id, Some(Color::rgb(200, 200, 220)));
 
                 // ── Group 1: 50% opacity ─────────────────────────────────
@@ -110,7 +110,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(100.0, 100.0), (400.0, 350.0)],
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
-                let group1 = renderer.add_shape(group1_bg, None, None);
+                let group1 = renderer.add_shape(group1_bg, None, None).unwrap();
                 renderer.set_shape_color(group1, Some(Color::rgb(255, 100, 100)));
 
                 // Child 1: overlapping blue rectangle
@@ -118,7 +118,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(120.0, 120.0), (300.0, 250.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let c1 = renderer.add_shape(child1, Some(group1), None);
+                let c1 = renderer.add_shape(child1, Some(group1), None).unwrap();
                 renderer.set_shape_color(c1, Some(Color::rgb(50, 100, 255)));
 
                 // Child 2: overlapping green rectangle
@@ -126,7 +126,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(200.0, 180.0), (380.0, 320.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let c2 = renderer.add_shape(child2, Some(group1), None);
+                let c2 = renderer.add_shape(child2, Some(group1), None).unwrap();
                 renderer.set_shape_color(c2, Some(Color::rgb(50, 200, 50)));
 
                 // Attach 50% opacity to group1
@@ -140,14 +140,14 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(350.0, 100.0), (700.0, 350.0)],
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
-                let group2 = renderer.add_shape(group2_bg, None, None);
+                let group2 = renderer.add_shape(group2_bg, None, None).unwrap();
                 renderer.set_shape_color(group2, Some(Color::rgb(255, 200, 50)));
 
                 let child3 = Shape::rect(
                     [(370.0, 130.0), (680.0, 320.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let c3 = renderer.add_shape(child3, Some(group2), None);
+                let c3 = renderer.add_shape(child3, Some(group2), None).unwrap();
                 renderer.set_shape_color(c3, Some(Color::rgb(128, 0, 200)));
 
                 let opacity2: f32 = 0.8;

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -104,7 +104,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(0.0, 0.0), (800.0, 600.0)],
                     Stroke::new(2.0, Color::rgb(255, 0, 0)),
                 );
-                let back_id = renderer.add_shape(background, None, None);
+                let back_id = renderer.add_shape(background, None, None).unwrap();
                 renderer.set_shape_color(back_id, Some(Color::BLACK));
 
                 // Draw a triangle — diagonal edges show aliasing clearly
@@ -115,7 +115,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     .line_to((320.0, 350.0))
                     .close()
                     .build();
-                let id = renderer.add_shape(triangle, Some(0), None);
+                let id = renderer.add_shape(triangle, Some(0), None).unwrap();
                 renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
 
                 // Draw a rounded rectangle — curved edges benefit from MSAA
@@ -124,7 +124,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(30.0),
                     Stroke::new(2.0, Color::rgb(255, 0, 0)),
                 );
-                let id2 = renderer.add_shape(rounded_rect, Some(0), None);
+                let id2 = renderer.add_shape(rounded_rect, Some(0), None).unwrap();
                 renderer.set_shape_color(id2, Some(Color::rgb(255, 100, 50)));
 
                 // Draw a circle (approximated with a rounded rect)
@@ -133,7 +133,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(80.0),
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let id3 = renderer.add_shape(circle, Some(0), None);
+                let id3 = renderer.add_shape(circle, Some(0), None).unwrap();
                 renderer.set_shape_color(id3, Some(Color::rgb(50, 200, 100)));
 
                 // Draw a small detailed shape - thin diagonal lines are great for MSAA testing
@@ -141,7 +141,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(400.0, 280.0), (550.0, 420.0)],
                     Stroke::new(1.0, Color::rgb(100, 0, 150)),
                 );
-                let id4 = renderer.add_shape(small_rect, None, None);
+                let id4 = renderer.add_shape(small_rect, None, None).unwrap();
                 renderer.set_shape_color(id4, Some(Color::rgb(200, 200, 255)));
 
                 match renderer.render() {

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -44,14 +44,16 @@ impl ApplicationHandler for App {
         ));
 
         // Create a simple rectangle shape
-        let shape_id = renderer.add_shape(
-            Shape::rect(
-                [(100.0, 100.0), (500.0, 400.0)],
-                Stroke::new(1.0, Color::BLACK),
-            ),
-            None,
-            None,
-        );
+        let shape_id = renderer
+            .add_shape(
+                Shape::rect(
+                    [(100.0, 100.0), (500.0, 400.0)],
+                    Stroke::new(1.0, Color::BLACK),
+                ),
+                None,
+                None,
+            )
+            .unwrap();
         renderer.set_shape_color(shape_id, Some(Color::rgb(200, 200, 200)));
 
         // Allocate two textures (background checker, foreground circle mask for demo)

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -230,7 +230,7 @@ impl<'a> ApplicationHandler for App<'a> {
                 // ── Scene background ─────────────────────────────────────
                 let scene_bg =
                     Shape::rect([(0.0, 0.0), (pw, ph)], Stroke::new(0.0, Color::TRANSPARENT));
-                let bg_id = renderer.add_shape(scene_bg, None, None);
+                let bg_id = renderer.add_shape(scene_bg, None, None).unwrap();
                 renderer.set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)));
 
                 // ── Colorful background content (for the blur to act on) ─
@@ -238,28 +238,28 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(40.0, 60.0), (300.0, 280.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let r1_id = renderer.add_shape(r1, Some(bg_id), None);
+                let r1_id = renderer.add_shape(r1, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)));
 
                 let r2 = Shape::rect(
                     [(200.0, 150.0), (500.0, 400.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let r2_id = renderer.add_shape(r2, Some(bg_id), None);
+                let r2_id = renderer.add_shape(r2, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)));
 
                 let r3 = Shape::rect(
                     [(400.0, 80.0), (700.0, 320.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let r3_id = renderer.add_shape(r3, Some(bg_id), None);
+                let r3_id = renderer.add_shape(r3, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)));
 
                 let r4 = Shape::rect(
                     [(100.0, 380.0), (650.0, 550.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
-                let r4_id = renderer.add_shape(r4, Some(bg_id), None);
+                let r4_id = renderer.add_shape(r4, Some(bg_id), None).unwrap();
                 renderer.set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)));
 
                 // ── Panel: parent with box shadow (group effect) ─────────
@@ -276,7 +276,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(panel_radius),
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
-                let panel = renderer.add_shape(panel_shape, None, None);
+                let panel = renderer.add_shape(panel_shape, None, None).unwrap();
                 // Fully transparent — the visual fill comes from the child
                 // with the backdrop blur. The parent only contributes the shadow.
                 renderer.set_shape_color(panel, Some(Color::TRANSPARENT));
@@ -306,7 +306,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(panel_radius),
                     Stroke::new(1.0, Color::rgba(255, 255, 255, 80)),
                 );
-                let glass = renderer.add_shape(glass_shape, Some(panel), None);
+                let glass = renderer.add_shape(glass_shape, Some(panel), None).unwrap();
                 // Semi-transparent white tint over the blurred background
                 renderer.set_shape_color(glass, Some(Color::rgba(255, 255, 255, 60)));
 

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -96,7 +96,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     ],
                     Stroke::new(0.0, Color::rgb(0, 0, 0)),
                 );
-                let background_id = renderer.add_shape(background, None, None);
+                let background_id = renderer.add_shape(background, None, None).unwrap();
                 renderer.set_shape_color(background_id, Some(Color::rgb(30, 30, 30)));
 
                 // A white rounded rect that we will texture
@@ -105,7 +105,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(20.0),
                     Stroke::new(2.0, Color::rgb(200, 200, 200)),
                 );
-                let rect_id = renderer.add_shape(textured_rect, Some(background_id), None);
+                let rect_id = renderer
+                    .add_shape(textured_rect, Some(background_id), None)
+                    .unwrap();
                 renderer.set_shape_color(rect_id, Some(Color::rgb(255, 255, 255))); // white so texture shows un-tinted
                                                                                     // Previously this shape used an offset of (100, 100)
                 renderer.set_shape_transform(

--- a/examples/star_wars_tilt.rs
+++ b/examples/star_wars_tilt.rs
@@ -83,14 +83,16 @@ impl<'a> ApplicationHandler for App<'a> {
                     // Create shape if it doesn't exist yet
                     if self.rect_id.is_none() {
                         // We need some background TODO: mention this in the docs
-                        let background = renderer.add_shape(
-                            Shape::rect(
-                                [(0.0, 0.0), (width as f32, height as f32)],
-                                Stroke::new(2.0, Color::TRANSPARENT),
-                            ),
-                            None,
-                            None,
-                        );
+                        let background = renderer
+                            .add_shape(
+                                Shape::rect(
+                                    [(0.0, 0.0), (width as f32, height as f32)],
+                                    Stroke::new(2.0, Color::TRANSPARENT),
+                                ),
+                                None,
+                                None,
+                            )
+                            .unwrap();
                         renderer.set_shape_color(background, Some(Color::rgb(30, 30, 30)));
 
                         // Create a 100x100 rectangle (matching the HTML)
@@ -100,7 +102,7 @@ impl<'a> ApplicationHandler for App<'a> {
                             Stroke::new(2.0, Color::TRANSPARENT),
                         );
 
-                        let rect_id = renderer.add_shape(rect_shape, None, None);
+                        let rect_id = renderer.add_shape(rect_shape, None, None).unwrap();
 
                         // Set the fill color to gold
                         renderer.set_shape_color(rect_id, Some(Color::TRANSPARENT));
@@ -111,12 +113,15 @@ impl<'a> ApplicationHandler for App<'a> {
                             Shape::rect([(0.0, 0.0), (35.0, 80.0)], Stroke::new(1.0, Color::BLACK));
 
                         // TODO: clip
-                        let inner_rect_1 = renderer.add_shape(inner_rect_shape.clone(), None, None);
+                        let inner_rect_1 = renderer
+                            .add_shape(inner_rect_shape.clone(), None, None)
+                            .unwrap();
                         renderer.set_shape_color(inner_rect_1, Some(Color::rgb(125, 0, 0)));
                         self.inner_rect_1 = Some(inner_rect_1);
 
                         // TODO: clip
-                        let inner_rect_2 = renderer.add_shape(inner_rect_shape, None, None);
+                        let inner_rect_2 =
+                            renderer.add_shape(inner_rect_shape, None, None).unwrap();
                         renderer.set_shape_color(inner_rect_2, Some(Color::rgb(0, 125, 0)));
                         self.inner_rect_2 = Some(inner_rect_2);
                     }

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -345,7 +345,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(0.0, 0.0), (logical_w, logical_h)],
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let background_id = renderer.add_shape(background, None, None);
+                let background_id = renderer.add_shape(background, None, None).unwrap();
                 renderer.set_shape_color(background_id, Some(Color::BLACK));
 
                 // Compute transforms in euclid space (same as before)
@@ -479,12 +479,12 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 ));
 
-                let red = renderer.add_shape(red_shape, None, None);
-                let green = renderer.add_shape(green_shape, None, None);
-                let blue = renderer.add_shape(blue_shape, None, None);
-                let jelly = renderer.add_shape(jelly_shape, None, None);
-                let heart = renderer.add_shape(heart_shape, None, None);
-                let perspective = renderer.add_shape(perspective_shape, None, None);
+                let red = renderer.add_shape(red_shape, None, None).unwrap();
+                let green = renderer.add_shape(green_shape, None, None).unwrap();
+                let blue = renderer.add_shape(blue_shape, None, None).unwrap();
+                let jelly = renderer.add_shape(jelly_shape, None, None).unwrap();
+                let heart = renderer.add_shape(heart_shape, None, None).unwrap();
+                let perspective = renderer.add_shape(perspective_shape, None, None).unwrap();
 
                 // Set per-instance colors
                 renderer.set_shape_color(

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -101,7 +101,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     ],
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let background_id = renderer.add_shape(background, None, None);
+                let background_id = renderer.add_shape(background, None, None).unwrap();
                 renderer.set_shape_color(background_id, Some(Color::rgb(255, 255, 200)));
 
                 let red = Shape::rounded_rect(
@@ -109,7 +109,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(0.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let red_id = renderer.add_shape(red, Some(background_id), None);
+                let red_id = renderer.add_shape(red, Some(background_id), None).unwrap();
                 renderer.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
 
                 let green = Shape::rounded_rect(
@@ -117,7 +117,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(0.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let green_id = renderer.add_shape(green, Some(red_id), None);
+                let green_id = renderer.add_shape(green, Some(red_id), None).unwrap();
                 renderer.set_shape_color(green_id, Some(Color::rgb(0, 255, 0)));
 
                 let blue = Shape::rounded_rect(
@@ -125,7 +125,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(10.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let blue_id = renderer.add_shape(blue, Some(green_id), None);
+                let blue_id = renderer.add_shape(blue, Some(green_id), None).unwrap();
                 renderer.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
 
                 let yellow = Shape::rounded_rect(
@@ -133,7 +133,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(0.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let yellow_id = renderer.add_shape(yellow, Some(green_id), None);
+                let yellow_id = renderer.add_shape(yellow, Some(green_id), None).unwrap();
                 renderer.set_shape_color(yellow_id, Some(Color::rgb(255, 255, 0)));
 
                 let white = Shape::rounded_rect(
@@ -141,7 +141,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(0.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let white_id = renderer.add_shape(white, Some(red_id), None);
+                let white_id = renderer.add_shape(white, Some(red_id), None).unwrap();
                 renderer.set_shape_color(white_id, Some(Color::rgb(255, 255, 255)));
 
                 let shape_that_doesnt_fit = Shape::rounded_rect(
@@ -149,7 +149,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(0.0),
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let doesnt_fit_id = renderer.add_shape(shape_that_doesnt_fit, Some(blue_id), None);
+                let doesnt_fit_id = renderer
+                    .add_shape(shape_that_doesnt_fit, Some(blue_id), None)
+                    .unwrap();
 
                 // ids were created above
 
@@ -191,9 +193,11 @@ impl<'a> ApplicationHandler for App<'a> {
                 let img_rect2 = img_rect1.clone();
                 let img_rect3 = img_rect1.clone();
 
-                let img_rect1_id = renderer.add_shape(img_rect1, Some(red_id), None);
-                let img_rect2_id = renderer.add_shape(img_rect2, Some(background_id), None);
-                let img_rect3_id = renderer.add_shape(img_rect3, None, None);
+                let img_rect1_id = renderer.add_shape(img_rect1, Some(red_id), None).unwrap();
+                let img_rect2_id = renderer
+                    .add_shape(img_rect2, Some(background_id), None)
+                    .unwrap();
+                let img_rect3_id = renderer.add_shape(img_rect3, None, None).unwrap();
 
                 renderer.set_shape_texture(img_rect1_id, Some(texture_id));
                 renderer.set_shape_texture(img_rect2_id, Some(texture_id));

--- a/examples/winit_softbuffer.rs
+++ b/examples/winit_softbuffer.rs
@@ -128,28 +128,32 @@ impl<'a> ApplicationHandler for App<'a> {
                     ],
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let bg_id = renderer_guard.add_shape(background, None, None);
+                let bg_id = renderer_guard.add_shape(background, None, None).unwrap();
                 renderer_guard.set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)));
 
-                let red_id = renderer_guard.add_shape(
-                    Shape::rect(
-                        [(0.0, 0.0), (200.0, 200.0)],
-                        Stroke::new(1.0, Color::rgb(0, 0, 0)),
-                    ),
-                    None,
-                    None,
-                );
+                let red_id = renderer_guard
+                    .add_shape(
+                        Shape::rect(
+                            [(0.0, 0.0), (200.0, 200.0)],
+                            Stroke::new(1.0, Color::rgb(0, 0, 0)),
+                        ),
+                        None,
+                        None,
+                    )
+                    .unwrap();
                 renderer_guard.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
                 renderer_guard.set_shape_transform(red_id, grafo::TransformInstance::identity());
 
-                let blue_id = renderer_guard.add_shape(
-                    Shape::rect(
-                        [(0.0, 0.0), (200.0, 200.0)],
-                        Stroke::new(1.0, Color::rgb(0, 0, 0)),
-                    ),
-                    None,
-                    None,
-                );
+                let blue_id = renderer_guard
+                    .add_shape(
+                        Shape::rect(
+                            [(0.0, 0.0), (200.0, 200.0)],
+                            Stroke::new(1.0, Color::rgb(0, 0, 0)),
+                        ),
+                        None,
+                        None,
+                    )
+                    .unwrap();
                 renderer_guard.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
                 renderer_guard.set_shape_transform(
                     blue_id,

--- a/examples/winit_softbuffer_cpu_swizzle.rs
+++ b/examples/winit_softbuffer_cpu_swizzle.rs
@@ -119,28 +119,32 @@ impl<'a> ApplicationHandler for App<'a> {
                     ],
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
-                let bg_id = renderer_guard.add_shape(background, None, None);
+                let bg_id = renderer_guard.add_shape(background, None, None).unwrap();
                 renderer_guard.set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)));
 
-                let red_id = renderer_guard.add_shape(
-                    Shape::rect(
-                        [(0.0, 0.0), (200.0, 200.0)],
-                        Stroke::new(1.0, Color::rgb(0, 0, 0)),
-                    ),
-                    None,
-                    None,
-                );
+                let red_id = renderer_guard
+                    .add_shape(
+                        Shape::rect(
+                            [(0.0, 0.0), (200.0, 200.0)],
+                            Stroke::new(1.0, Color::rgb(0, 0, 0)),
+                        ),
+                        None,
+                        None,
+                    )
+                    .unwrap();
                 renderer_guard.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
                 renderer_guard.set_shape_transform(red_id, grafo::TransformInstance::identity());
 
-                let blue_id = renderer_guard.add_shape(
-                    Shape::rect(
-                        [(0.0, 0.0), (200.0, 200.0)],
-                        Stroke::new(1.0, Color::rgb(0, 0, 0)),
-                    ),
-                    None,
-                    None,
-                );
+                let blue_id = renderer_guard
+                    .add_shape(
+                        Shape::rect(
+                            [(0.0, 0.0), (200.0, 200.0)],
+                            Stroke::new(1.0, Color::rgb(0, 0, 0)),
+                        ),
+                        None,
+                        None,
+                    )
+                    .unwrap();
                 renderer_guard.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
                 renderer_guard.set_shape_transform(
                     blue_id,

--- a/examples/winit_transparency.rs
+++ b/examples/winit_transparency.rs
@@ -72,7 +72,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     [(100.0, 100.0), (300.0, 200.0)],
                     Stroke::new(3.0, Color::BLACK),
                 );
-                let id = renderer.add_shape(rect, None, None);
+                let id = renderer.add_shape(rect, None, None).unwrap();
                 renderer.set_shape_color(id, Some(Color::rgb(255, 100, 50)));
 
                 // Create a rounded rectangle to test different shapes
@@ -81,7 +81,7 @@ impl<'a> ApplicationHandler for App<'a> {
                     BorderRadii::new(50.0),
                     Stroke::new(2.0, Color::rgb(0, 100, 200)),
                 );
-                let rid = renderer.add_shape(rounded_rect, None, None);
+                let rid = renderer.add_shape(rounded_rect, None, None).unwrap();
                 renderer.set_shape_color(rid, Some(Color::rgb(100, 200, 255)));
 
                 // Render the frame

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -43,7 +43,7 @@ pub fn build_main_scene(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(0.0, 0.0), (CANVAS_WIDTH as f32, CANVAS_HEIGHT as f32)],
         Stroke::default(),
     );
-    let canvas_root_id = renderer.add_shape(canvas_root, None, None);
+    let canvas_root_id = renderer.add_shape(canvas_root, None, None).unwrap();
     renderer.set_shape_color(canvas_root_id, Some(Color::WHITE));
 
     load_shared_resources(renderer);
@@ -145,7 +145,7 @@ fn tile_01_rect_solid(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(220, 50, 50)));
 
     vec![
@@ -168,7 +168,7 @@ fn tile_02_rounded_rect_solid(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         BorderRadii::new(15.0),
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(50, 180, 50)));
 
     vec![
@@ -193,7 +193,7 @@ fn tile_03_path_triangle(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         .line_to((ox + 10.0, oy + 70.0))
         .close()
         .build();
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(50, 50, 220)));
 
     vec![
@@ -225,7 +225,7 @@ fn tile_04_path_bezier(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         )
         .close()
         .build();
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(220, 200, 50)));
 
     vec![
@@ -249,14 +249,14 @@ fn tile_05_rect_parent_child_inside(renderer: &mut Renderer) -> Vec<PixelExpecta
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
 
     let child = Shape::rect(
         [(ox + 20.0, oy + 20.0), (ox + 60.0, oy + 60.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(220, 100, 50)));
 
     vec![
@@ -285,7 +285,7 @@ fn tile_06_rect_parent_child_overflow(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 10.0, oy + 10.0), (ox + 55.0, oy + 70.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(150, 200, 150)));
 
     // Child extends past parent's right edge
@@ -293,7 +293,7 @@ fn tile_06_rect_parent_child_overflow(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 30.0, oy + 20.0), (ox + 75.0, oy + 60.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 200)));
 
     vec![
@@ -332,7 +332,7 @@ fn tile_07_rect_parent_multi_children(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)));
 
     let child_colors = [
@@ -347,7 +347,7 @@ fn tile_07_rect_parent_multi_children(renderer: &mut Renderer) -> Vec<PixelExpec
             [(ox + 15.0, oy + y_start), (ox + 65.0, oy + y_end)],
             Stroke::default(),
         );
-        let child_id = renderer.add_shape(child, Some(parent_id), None);
+        let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
         renderer.set_shape_color(child_id, Some(child_colors[idx]));
     }
 
@@ -378,21 +378,21 @@ fn tile_08_rect_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let id0 = renderer.add_shape(level0, None, None);
+    let id0 = renderer.add_shape(level0, None, None).unwrap();
     renderer.set_shape_color(id0, Some(Color::rgb(200, 180, 180)));
 
     let level1 = Shape::rect(
         [(ox + 15.0, oy + 15.0), (ox + 65.0, oy + 65.0)],
         Stroke::default(),
     );
-    let id1 = renderer.add_shape(level1, Some(id0), None);
+    let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
     renderer.set_shape_color(id1, Some(Color::rgb(180, 200, 180)));
 
     let level2 = Shape::rect(
         [(ox + 25.0, oy + 25.0), (ox + 55.0, oy + 55.0)],
         Stroke::default(),
     );
-    let id2 = renderer.add_shape(level2, Some(id1), None);
+    let id2 = renderer.add_shape(level2, Some(id1), None).unwrap();
     renderer.set_shape_color(id2, Some(Color::rgb(100, 100, 220)));
 
     vec![
@@ -415,7 +415,7 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)));
 
     // First child (drawn first)
@@ -423,7 +423,7 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 15.0, oy + 20.0), (ox + 50.0, oy + 55.0)],
         Stroke::default(),
     );
-    let c1 = renderer.add_shape(child1, Some(parent_id), None);
+    let c1 = renderer.add_shape(child1, Some(parent_id), None).unwrap();
     renderer.set_shape_color(c1, Some(Color::rgb(220, 50, 50)));
 
     // Second child overlaps first (drawn on top)
@@ -431,7 +431,7 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 30.0, oy + 30.0), (ox + 65.0, oy + 65.0)],
         Stroke::default(),
     );
-    let c2 = renderer.add_shape(child2, Some(parent_id), None);
+    let c2 = renderer.add_shape(child2, Some(parent_id), None).unwrap();
     renderer.set_shape_color(c2, Some(Color::rgb(50, 50, 220)));
 
     vec![
@@ -467,7 +467,7 @@ fn tile_10_rounded_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         BorderRadii::new(20.0),
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 230)));
 
     // Child is smaller than parent, leaving a visible parent ring
@@ -475,7 +475,7 @@ fn tile_10_rounded_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 15.0, oy + 15.0), (ox + 65.0, oy + 65.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(220, 100, 50)));
 
     vec![
@@ -511,7 +511,7 @@ fn tile_11_path_parent_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         .line_to((ox + 5.0, oy + 70.0))
         .close()
         .build();
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
 
     // Child rect offset to the right so left part of triangle shows parent color
@@ -519,7 +519,7 @@ fn tile_11_path_parent_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 35.0, oy + 15.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(220, 150, 50)));
 
     vec![
@@ -562,7 +562,7 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         BorderRadii::new(10.0),
         Stroke::default(),
     );
-    let id0 = renderer.add_shape(level0, None, None);
+    let id0 = renderer.add_shape(level0, None, None).unwrap();
     renderer.set_shape_color(id0, Some(Color::rgb(200, 180, 200))); // lavender
 
     // L1: shifted SE — overflows L0 right and bottom.
@@ -572,7 +572,7 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         BorderRadii::new(8.0),
         Stroke::default(),
     );
-    let id1 = renderer.add_shape(level1, Some(id0), None);
+    let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
     renderer.set_shape_color(id1, Some(Color::rgb(100, 200, 100))); // green
 
     // L2: shifted SW/down — overflows L1 to the left and L0 below.
@@ -582,7 +582,7 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         BorderRadii::new(8.0),
         Stroke::default(),
     );
-    let id2 = renderer.add_shape(level2, Some(id1), None);
+    let id2 = renderer.add_shape(level2, Some(id1), None).unwrap();
     renderer.set_shape_color(id2, Some(Color::rgb(100, 100, 220))); // blue
 
     vec![
@@ -644,7 +644,7 @@ fn tile_13_rotated_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(13);
     // Parent rect defined centered at origin, then rotated+translated
     let parent = Shape::rect([(-20.0, -20.0), (20.0, 20.0)], Stroke::default());
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 180)));
     let rotation = TransformInstance::rotation_z_deg(45.0);
     let translation = TransformInstance::translation(ox + 40.0, oy + 40.0);
@@ -653,7 +653,7 @@ fn tile_13_rotated_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
 
     // Child is smaller than parent — parent ring visible around child
     let child = Shape::rect([(-12.0, -12.0), (12.0, 12.0)], Stroke::default());
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(220, 80, 80)));
     renderer.set_shape_transform(child_id, rotation.multiply(&translation));
 
@@ -699,7 +699,7 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 5.0, oy + 5.0), (ox + 60.0, oy + 60.0)],
         Stroke::default(),
     );
-    let id0 = renderer.add_shape(level0, None, None);
+    let id0 = renderer.add_shape(level0, None, None).unwrap();
     renderer.set_shape_color(id0, Some(Color::rgb(200, 200, 200))); // gray
 
     // L1: rounded-rect shifted SE — overflows L0 right and bottom → stencil clip.
@@ -709,7 +709,7 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         BorderRadii::new(10.0),
         Stroke::default(),
     );
-    let id1 = renderer.add_shape(level1, Some(id0), None);
+    let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
     renderer.set_shape_color(id1, Some(Color::rgb(180, 220, 180))); // green
 
     // Leaf: rect shifted SW/down — overflows L1 to the left and L0 below.
@@ -718,7 +718,7 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 10.0, oy + 35.0), (ox + 50.0, oy + 75.0)],
         Stroke::default(),
     );
-    let leaf_id = renderer.add_shape(leaf, Some(id1), None);
+    let leaf_id = renderer.add_shape(leaf, Some(id1), None).unwrap();
     renderer.set_shape_color(leaf_id, Some(Color::rgb(50, 50, 200))); // blue
 
     vec![
@@ -785,7 +785,7 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         BorderRadii::new(12.0),
         Stroke::default(),
     );
-    let id0 = renderer.add_shape(level0, None, None);
+    let id0 = renderer.add_shape(level0, None, None).unwrap();
     renderer.set_shape_color(id0, Some(Color::rgb(220, 200, 200))); // pink
 
     // L1: rect shifted SE — overflows L0 right and bottom → scissor clip.
@@ -794,7 +794,7 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 20.0, oy + 20.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let id1 = renderer.add_shape(level1, Some(id0), None);
+    let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
     renderer.set_shape_color(id1, Some(Color::rgb(200, 220, 200))); // green
 
     // Leaf: rect shifted SW/down — overflows L1 to the left and L0 below.
@@ -803,7 +803,7 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 10.0, oy + 35.0), (ox + 50.0, oy + 75.0)],
         Stroke::default(),
     );
-    let leaf_id = renderer.add_shape(leaf, Some(id1), None);
+    let leaf_id = renderer.add_shape(leaf, Some(id1), None).unwrap();
     renderer.set_shape_color(leaf_id, Some(Color::rgb(50, 200, 50))); // bright green
 
     vec![
@@ -869,7 +869,7 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 5.0, oy + 5.0), (ox + 55.0, oy + 75.0)],
         Stroke::default(),
     );
-    let id0 = renderer.add_shape(l0, None, None);
+    let id0 = renderer.add_shape(l0, None, None).unwrap();
     renderer.set_shape_color(id0, Some(Color::rgb(220, 220, 220))); // light gray
 
     // L1: rect, wide top portion — overflows L0 to right → scissor.
@@ -878,7 +878,7 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 20.0, oy + 5.0), (ox + 75.0, oy + 55.0)],
         Stroke::default(),
     );
-    let id1 = renderer.add_shape(l1, Some(id0), None);
+    let id1 = renderer.add_shape(l1, Some(id0), None).unwrap();
     renderer.set_shape_color(id1, Some(Color::rgb(200, 200, 220))); // blue-gray
 
     // L2: rounded-rect, tall — overflows L1 below → stencil.
@@ -888,7 +888,7 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         BorderRadii::new(10.0),
         Stroke::default(),
     );
-    let id2 = renderer.add_shape(l2, Some(id1), None);
+    let id2 = renderer.add_shape(l2, Some(id1), None).unwrap();
     renderer.set_shape_color(id2, Some(Color::rgb(180, 220, 180))); // green
 
     // L3: rect, wide — overflows L2 right and above → scissor.
@@ -897,7 +897,7 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 25.0, oy + 10.0), (ox + 70.0, oy + 50.0)],
         Stroke::default(),
     );
-    let id3 = renderer.add_shape(l3, Some(id2), None);
+    let id3 = renderer.add_shape(l3, Some(id2), None).unwrap();
     renderer.set_shape_color(id3, Some(Color::rgb(200, 180, 220))); // purple
 
     // L4: leaf rect — overflows L3 left and below.
@@ -906,7 +906,7 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 10.0, oy + 30.0), (ox + 45.0, oy + 65.0)],
         Stroke::default(),
     );
-    let id4 = renderer.add_shape(l4, Some(id3), None);
+    let id4 = renderer.add_shape(l4, Some(id3), None).unwrap();
     renderer.set_shape_color(id4, Some(Color::rgb(50, 50, 200))); // blue
 
     vec![
@@ -971,7 +971,7 @@ fn tile_17_translated_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(17);
     // Rect defined at origin, translated to bottom-right of tile
     let shape = Shape::rect([(0.0, 0.0), (40.0, 25.0)], Stroke::default());
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(220, 150, 50)));
     renderer.set_shape_transform(id, TransformInstance::translation(ox + 30.0, oy + 45.0));
 
@@ -1014,7 +1014,7 @@ fn tile_18_scaled_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(150, 50, 200)));
     // Scale 0.5× horizontal, 1.0× vertical around tile center
     let to_origin = TransformInstance::translation(-(ox + 40.0), -(oy + 40.0));
@@ -1058,7 +1058,7 @@ fn tile_18_scaled_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
 fn tile_19_rotated_rect_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(19);
     let shape = Shape::rect([(-15.0, -15.0), (15.0, 15.0)], Stroke::default());
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(220, 100, 100)));
     let rotation = TransformInstance::rotation_z_deg(45.0);
     let translation = TransformInstance::translation(ox + 40.0, oy + 40.0);
@@ -1082,7 +1082,7 @@ fn tile_20_transform_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectati
     let (ox, oy) = tile_origin(20);
     // Parent translated
     let parent = Shape::rect([(0.0, 0.0), (50.0, 50.0)], Stroke::default());
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
     renderer.set_shape_transform(
         parent_id,
@@ -1091,7 +1091,7 @@ fn tile_20_transform_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectati
 
     // Child at local (10,10)-(40,40) — ends up at tile (25,25)-(55,55)
     let child = Shape::rect([(10.0, 10.0), (40.0, 40.0)], Stroke::default());
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(50, 200, 50)));
     renderer.set_shape_transform(
         child_id,
@@ -1113,7 +1113,7 @@ fn tile_21_alpha_overlap(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 50.0, oy + 60.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(50, 50, 220)));
 
     // Semi-transparent red on top
@@ -1121,7 +1121,7 @@ fn tile_21_alpha_overlap(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 25.0, oy + 20.0), (ox + 65.0, oy + 55.0)],
         Stroke::default(),
     );
-    let fg_id = renderer.add_shape(fg, None, None);
+    let fg_id = renderer.add_shape(fg, None, None).unwrap();
     renderer.set_shape_color(fg_id, Some(Color::rgba(220, 50, 50, 128)));
 
     vec![
@@ -1162,7 +1162,7 @@ fn tile_22_no_color_default(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(100, 100, 200)));
 
     let shape = Shape::rect(
@@ -1170,7 +1170,7 @@ fn tile_22_no_color_default(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     // No set_shape_color call — defaults to transparent
-    renderer.add_shape(shape, None, None);
+    renderer.add_shape(shape, None, None).unwrap();
 
     vec![
         // Shape center — transparent, so the background shows through
@@ -1200,7 +1200,7 @@ fn tile_23_fully_transparent(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 15.0, oy + 15.0), (ox + 65.0, oy + 65.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::TRANSPARENT));
 
     // Transparent shape over white canvas root → shows white
@@ -1222,7 +1222,7 @@ fn tile_24_textured_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID));
     // White color so texture shows through unmodified
     renderer.set_shape_color(id, Some(Color::WHITE));
@@ -1258,7 +1258,7 @@ fn tile_25_textured_with_color(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID));
     renderer.set_shape_color(id, Some(Color::rgb(255, 100, 100)));
 
@@ -1291,7 +1291,7 @@ fn tile_26_textured_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_texture(parent_id, Some(CHECKERBOARD_TEXTURE_ID));
     renderer.set_shape_color(parent_id, Some(Color::WHITE));
 
@@ -1299,7 +1299,7 @@ fn tile_26_textured_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 25.0, oy + 25.0), (ox + 55.0, oy + 55.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(220, 50, 50)));
 
     vec![
@@ -1336,7 +1336,7 @@ fn tile_27_group_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 5.0, oy + 30.0), (ox + 75.0, oy + 50.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg_stripe, None, None);
+    let bg_id = renderer.add_shape(bg_stripe, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50))); // green stripe
 
     // Blurred shape (slightly transparent so stripe shows through)
@@ -1344,7 +1344,7 @@ fn tile_27_group_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 15.0, oy + 10.0), (ox + 65.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgba(220, 50, 50, 200))); // semi-transparent red
 
     let (pw, ph) = renderer.size();
@@ -1390,7 +1390,7 @@ fn tile_28_group_blur_with_children(renderer: &mut Renderer) -> Vec<PixelExpecta
         [(ox + 5.0, oy + 30.0), (ox + 75.0, oy + 50.0)],
         Stroke::default(),
     );
-    let bg_stripe_id = renderer.add_shape(bg_stripe, None, None);
+    let bg_stripe_id = renderer.add_shape(bg_stripe, None, None).unwrap();
     renderer.set_shape_color(bg_stripe_id, Some(Color::rgb(220, 180, 50))); // yellow stripe
 
     // Blurred parent (group effect applies to parent+child as a unit)
@@ -1398,14 +1398,14 @@ fn tile_28_group_blur_with_children(renderer: &mut Renderer) -> Vec<PixelExpecta
         [(ox + 10.0, oy + 5.0), (ox + 70.0, oy + 75.0)],
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_color(parent_id, Some(Color::rgba(200, 200, 200, 200))); // semi-transparent gray
 
     let child = Shape::rect(
         [(ox + 20.0, oy + 20.0), (ox + 60.0, oy + 60.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 220)));
 
     let (pw, ph) = renderer.size();
@@ -1452,7 +1452,7 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)));
 
     // Sharp-edged stripe that partially overlaps the backdrop panel.
@@ -1461,7 +1461,7 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         [(ox + 10.0, oy + 32.0), (ox + 70.0, oy + 48.0)],
         Stroke::default(),
     );
-    let stripe_id = renderer.add_shape(stripe, None, None);
+    let stripe_id = renderer.add_shape(stripe, None, None).unwrap();
     renderer.set_shape_color(stripe_id, Some(Color::rgb(50, 50, 220))); // blue stripe
 
     // Backdrop blur panel on top (leaf, no children)
@@ -1469,7 +1469,7 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         [(ox + 20.0, oy + 15.0), (ox + 60.0, oy + 65.0)],
         Stroke::default(),
     );
-    let panel_id = renderer.add_shape(panel, None, None);
+    let panel_id = renderer.add_shape(panel, None, None).unwrap();
     renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
 
     let (pw, ph) = renderer.size();
@@ -1515,7 +1515,7 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50)));
 
     // Sharp-edged stripe partially behind the backdrop panel
@@ -1523,7 +1523,7 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 8.0, oy + 30.0), (ox + 72.0, oy + 50.0)],
         Stroke::default(),
     );
-    let stripe_id = renderer.add_shape(stripe, None, None);
+    let stripe_id = renderer.add_shape(stripe, None, None).unwrap();
     renderer.set_shape_color(stripe_id, Some(Color::rgb(220, 50, 50))); // red stripe
 
     // Backdrop panel with a child
@@ -1531,14 +1531,14 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 15.0, oy + 10.0), (ox + 65.0, oy + 70.0)],
         Stroke::default(),
     );
-    let panel_id = renderer.add_shape(panel, None, None);
+    let panel_id = renderer.add_shape(panel, None, None).unwrap();
     renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
 
     let child = Shape::rect(
         [(ox + 25.0, oy + 50.0), (ox + 55.0, oy + 65.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(panel_id), None);
+    let child_id = renderer.add_shape(child, Some(panel_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 220)));
 
     let (pw, ph) = renderer.size();
@@ -1582,7 +1582,7 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(220, 180, 50)));
 
     // Sharp-edged blue stripe as child of bg — partially behind the backdrop panel
@@ -1590,7 +1590,7 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 8.0, oy + 32.0), (ox + 72.0, oy + 48.0)],
         Stroke::default(),
     );
-    let stripe_id = renderer.add_shape(stripe, Some(bg_id), None);
+    let stripe_id = renderer.add_shape(stripe, Some(bg_id), None).unwrap();
     renderer.set_shape_color(stripe_id, Some(Color::rgb(50, 50, 200))); // blue stripe
 
     // Scissor-clipping parent (child of bg, sibling of stripe — drawn after stripe)
@@ -1598,7 +1598,7 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 10.0, oy + 10.0), (ox + 60.0, oy + 70.0)],
         Stroke::default(),
     );
-    let clip_id = renderer.add_shape(clip_parent, Some(bg_id), None);
+    let clip_id = renderer.add_shape(clip_parent, Some(bg_id), None).unwrap();
     renderer.set_shape_color(clip_id, Some(Color::rgba(0, 0, 0, 0))); // transparent — just clips
 
     // Backdrop panel inside scissor-clipped parent
@@ -1606,7 +1606,7 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 15.0, oy + 15.0), (ox + 55.0, oy + 65.0)],
         Stroke::default(),
     );
-    let panel_id = renderer.add_shape(panel, Some(clip_id), None);
+    let panel_id = renderer.add_shape(panel, Some(clip_id), None).unwrap();
     renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
 
     let (pw, ph) = renderer.size();
@@ -1660,7 +1660,7 @@ fn tile_32_tiny_1px_shape(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 40.0, oy + 40.0), (ox + 41.0, oy + 41.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(255, 0, 255)));
 
     // Small shape — check that the general area has some color
@@ -1685,7 +1685,7 @@ fn tile_33_shape_at_canvas_edge(renderer: &mut Renderer) -> Vec<PixelExpectation
         [(ox + 50.0, oy + 50.0), (ox + 120.0, oy + 120.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(180, 50, 180)));
 
     vec![
@@ -1710,7 +1710,9 @@ fn tile_34_cached_shape(renderer: &mut Renderer) -> Vec<PixelExpectation> {
 
     let cache_key = 9999;
     renderer.load_shape(shape, cache_key, None);
-    let id = renderer.add_cached_shape_to_the_render_queue(cache_key, None);
+    let id = renderer
+        .add_cached_shape_to_the_render_queue(cache_key, None)
+        .unwrap();
     renderer.set_shape_color(id, Some(Color::rgb(50, 180, 220)));
 
     vec![
@@ -1741,11 +1743,11 @@ fn tile_35_trivial_transform_transparent_leaf(renderer: &mut Renderer) -> Vec<Pi
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(40, 90, 200)));
 
     let leaf = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
-    let leaf_id = renderer.add_shape(leaf, None, None);
+    let leaf_id = renderer.add_shape(leaf, None, None).unwrap();
     renderer.set_shape_transform(
         leaf_id,
         TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
@@ -1765,7 +1767,7 @@ fn tile_36_trivial_transform_transparent_parent(renderer: &mut Renderer) -> Vec<
     let (ox, oy) = tile_origin(36);
 
     let parent = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_transform(
         parent_id,
         TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
@@ -1775,7 +1777,7 @@ fn tile_36_trivial_transform_transparent_parent(renderer: &mut Renderer) -> Vec<
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 40.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(30, 110, 220)));
 
     vec![
@@ -1805,7 +1807,7 @@ fn tile_37_textured_transparent_rects(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 10.0, oy + 10.0), (ox + 30.0, oy + 30.0)],
         Stroke::default(),
     );
-    let explicit_alpha_zero_id = renderer.add_shape(explicit_alpha_zero, None, None);
+    let explicit_alpha_zero_id = renderer.add_shape(explicit_alpha_zero, None, None).unwrap();
     renderer.set_shape_color(explicit_alpha_zero_id, Some(Color::rgba(255, 0, 0, 0)));
     renderer.set_shape_texture(explicit_alpha_zero_id, Some(SOLID_GREEN_TEXTURE_ID));
 
@@ -1813,7 +1815,7 @@ fn tile_37_textured_transparent_rects(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 40.0, oy + 10.0), (ox + 60.0, oy + 30.0)],
         Stroke::default(),
     );
-    let none_color_id = renderer.add_shape(none_color, None, None);
+    let none_color_id = renderer.add_shape(none_color, None, None).unwrap();
     renderer.set_shape_texture(none_color_id, Some(SOLID_GREEN_TEXTURE_ID));
 
     vec![
@@ -1840,7 +1842,7 @@ fn tile_38_sheared_transparent_parent(renderer: &mut Renderer) -> Vec<PixelExpec
     let (ox, oy) = tile_origin(38);
 
     let parent = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
     renderer.set_shape_transform(
         parent_id,
         TransformInstance::affine_2d(1.0, 0.0, 0.5, 1.0, ox + 20.0, oy + 20.0),
@@ -1850,7 +1852,7 @@ fn tile_38_sheared_transparent_parent(renderer: &mut Renderer) -> Vec<PixelExpec
         [(ox + 15.0, oy + 15.0), (ox + 55.0, oy + 45.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(20, 120, 230)));
 
     vec![
@@ -1913,7 +1915,7 @@ fn two_stop_common_with_units(
 fn tile_39_linear_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(39);
     let shape = Shape::rect([(0.0, 0.0), (60.0, 60.0)], Stroke::default());
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_transform(id, TransformInstance::translation(ox + 10.0, oy + 10.0));
 
     let gradient = Gradient::linear(LinearGradientDesc {
@@ -1959,7 +1961,7 @@ fn tile_40_radial_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let gradient = Gradient::radial(RadialGradientDesc {
         common: two_stop_common((240, 240, 30), (30, 180, 30), SpreadMode::Pad),
@@ -2002,7 +2004,7 @@ fn tile_41_conic_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let tau = std::f32::consts::TAU;
     let gradient = Gradient::conic(ConicGradientDesc {
@@ -2086,7 +2088,7 @@ fn tile_42_repeating_linear_gradient(renderer: &mut Renderer) -> Vec<PixelExpect
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: GradientCommonDesc {
@@ -2168,7 +2170,7 @@ fn tile_43_gradient_hard_stops(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: GradientCommonDesc {
@@ -2262,14 +2264,14 @@ fn tile_44_gradient_clipped(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         BorderRadii::new(15.0),
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
 
     // Child rect filled with a gradient, clipped by rounded parent.
     let child = Shape::rect(
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common((30, 220, 30), (220, 30, 220), SpreadMode::Pad),
@@ -2314,7 +2316,7 @@ fn tile_45_gradient_group_blur(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 5.0, oy + 30.0), (ox + 75.0, oy + 50.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg_stripe, None, None);
+    let bg_id = renderer.add_shape(bg_stripe, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50))); // green stripe
 
     // Gradient-filled shape with group blur
@@ -2322,7 +2324,7 @@ fn tile_45_gradient_group_blur(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 15.0, oy + 10.0), (ox + 65.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common((220, 50, 50), (50, 50, 220), SpreadMode::Pad),
@@ -2379,7 +2381,7 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 5.0, oy + 5.0), (ox + 75.0, oy + 75.0)],
         Stroke::default(),
     );
-    let bg_id = renderer.add_shape(bg, None, None);
+    let bg_id = renderer.add_shape(bg, None, None).unwrap();
     renderer.set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)));
 
     // Gradient stripe that partially overlaps the backdrop panel.
@@ -2388,7 +2390,7 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 10.0, oy + 32.0), (ox + 70.0, oy + 48.0)],
         Stroke::default(),
     );
-    let stripe_id = renderer.add_shape(stripe, None, None);
+    let stripe_id = renderer.add_shape(stripe, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common((50, 50, 220), (50, 220, 50), SpreadMode::Pad),
@@ -2406,7 +2408,7 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         [(ox + 20.0, oy + 15.0), (ox + 60.0, oy + 65.0)],
         Stroke::default(),
     );
-    let panel_id = renderer.add_shape(panel, None, None);
+    let panel_id = renderer.add_shape(panel, None, None).unwrap();
     renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
 
     let (pw, ph) = renderer.size();
@@ -2459,7 +2461,7 @@ fn tile_47_gradient_nonleaf_stencil(renderer: &mut Renderer) -> Vec<PixelExpecta
         BorderRadii::new(12.0),
         Stroke::default(),
     );
-    let parent_id = renderer.add_shape(parent, None, None);
+    let parent_id = renderer.add_shape(parent, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common((220, 30, 30), (30, 30, 220), SpreadMode::Pad),
@@ -2477,7 +2479,7 @@ fn tile_47_gradient_nonleaf_stencil(renderer: &mut Renderer) -> Vec<PixelExpecta
         [(ox + 30.0, oy + 30.0), (ox + 50.0, oy + 50.0)],
         Stroke::default(),
     );
-    let child_id = renderer.add_shape(child, Some(parent_id), None);
+    let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
     renderer.set_shape_color(child_id, Some(Color::rgb(255, 255, 0))); // yellow
 
     vec![
@@ -2523,7 +2525,7 @@ fn tile_48_gradient_state_leak(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 5.0, oy + 10.0), (ox + 37.0, oy + 70.0)],
         Stroke::default(),
     );
-    let grad_id = renderer.add_shape(grad_shape, None, None);
+    let grad_id = renderer.add_shape(grad_shape, None, None).unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common((220, 30, 30), (30, 220, 30), SpreadMode::Pad),
@@ -2541,7 +2543,7 @@ fn tile_48_gradient_state_leak(renderer: &mut Renderer) -> Vec<PixelExpectation>
         [(ox + 43.0, oy + 10.0), (ox + 75.0, oy + 70.0)],
         Stroke::default(),
     );
-    let solid_id = renderer.add_shape(solid_shape, None, None);
+    let solid_id = renderer.add_shape(solid_shape, None, None).unwrap();
     renderer.set_shape_color(solid_id, Some(Color::rgb(0, 220, 220))); // cyan
 
     vec![
@@ -2579,7 +2581,7 @@ fn tile_49_conic_quadrant_colors(renderer: &mut Renderer) -> Vec<PixelExpectatio
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
         Stroke::default(),
     );
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     use std::f32::consts::{FRAC_PI_2, PI, TAU};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //!             [(0.0, 0.0), (200.0, 100.0)],
 //!             Stroke::new(2.0, Color::BLACK), // Black stroke with width 2.0
 //!         );
-//!         let rect_id = renderer.add_shape(rect, None, None);
+//!         let rect_id = renderer.add_shape(rect, None, None).expect("to add shape to the renderer");
 //!         // Set per-instance fill color (shapes are transparent by default)
 //!         renderer.set_shape_color(rect_id, Some(Color::rgb(0, 128, 255)));
 //!         renderer.set_shape_transform(rect_id, grafo::TransformInstance::identity());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,14 +161,10 @@ pub use gradient::types::{
     GradientUnits, HueComponent, HueInterpolationMethod, LinearGradientDesc, LinearGradientLine,
     RadialGradientDesc, RadialGradientShape, RadialGradientSize, SpreadMode,
 };
-pub use renderer::MathRect;
-pub use renderer::Renderer;
-pub use renderer::RendererCreationError;
-pub use renderer::TextureLayer;
+pub use renderer::{MathRect, Renderer, RendererCreationError, TextureLayer, types::DrawCommandError};
 pub use shape::*;
 pub use stroke::Stroke;
-pub use texture_manager::premultiply_rgba8_srgb_inplace;
-pub use texture_manager::TextureManager;
+pub use texture_manager::{premultiply_rgba8_srgb_inplace, TextureManager};
 pub use vertex::InstanceTransform as TransformInstance;
 
 #[cfg(feature = "render_metrics")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,9 @@ pub use gradient::types::{
     GradientUnits, HueComponent, HueInterpolationMethod, LinearGradientDesc, LinearGradientLine,
     RadialGradientDesc, RadialGradientShape, RadialGradientSize, SpreadMode,
 };
-pub use renderer::{MathRect, Renderer, RendererCreationError, TextureLayer, types::DrawCommandError};
+pub use renderer::{
+    types::DrawCommandError, MathRect, Renderer, RendererCreationError, TextureLayer,
+};
 pub use shape::*;
 pub use stroke::Stroke;
 pub use texture_manager::{premultiply_rgba8_srgb_inplace, TextureManager};

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -45,7 +45,7 @@ pub use construction::RendererCreationError;
 mod rendering;
 mod surface;
 mod traversal;
-mod types;
+pub(crate) mod types;
 
 pub type MathRect = lyon::math::Box2D;
 

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -1,11 +1,6 @@
 use super::*;
 use crate::gradient::types::Fill;
-
-#[derive(thiserror::Error, Debug)]
-pub enum DrawCommandError {
-    #[error("Shape with id {0} doesn't exist in the draw tree.")]
-    InvalidShapeId(usize),
-}
+use super::types::DrawCommandError;
 
 impl<'a> Renderer<'a> {
     pub fn add_shape(

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -1,13 +1,19 @@
 use super::*;
 use crate::gradient::types::Fill;
 
+#[derive(thiserror::Error, Debug)]
+pub enum DrawCommandError {
+    #[error("Shape with id {0} doesn't exist in the draw tree.")]
+    InvalidShapeId(usize),
+}
+
 impl<'a> Renderer<'a> {
     pub fn add_shape(
         &mut self,
         shape: impl Into<Shape>,
         clip_to_shape: Option<usize>,
         cache_key: Option<u64>,
-    ) -> usize {
+    ) -> Result<usize, DrawCommandError> {
         self.add_draw_command(
             DrawCommand::Shape(ShapeDrawData::new(shape, cache_key)),
             clip_to_shape,
@@ -33,7 +39,7 @@ impl<'a> Renderer<'a> {
         &mut self,
         cache_key: u64,
         clip_to_shape: Option<usize>,
-    ) -> usize {
+    ) -> Result<usize, DrawCommandError> {
         let draw_data = if let Some(cached) = self.shape_cache.get(&cache_key) {
             if cached.is_rect {
                 if let Some(bounds) = cached.rect_bounds {
@@ -67,24 +73,23 @@ impl<'a> Renderer<'a> {
         &mut self,
         draw_command: DrawCommand,
         clip_to_shape: Option<usize>,
-    ) -> usize {
+    ) -> Result<usize, DrawCommandError> {
         if self.draw_tree.is_empty() {
-            self.draw_tree.add_node(draw_command)
+            Ok(self.draw_tree.add_node(draw_command))
         } else if let Some(clip_to_shape) = clip_to_shape {
             // Mark the parent as non-leaf since it now has a child.
             if let Some(parent) = self.draw_tree.get_mut(clip_to_shape) {
                 parent.set_not_leaf();
-                self.draw_tree.add_child(clip_to_shape, draw_command)
+                Ok(self.draw_tree.add_child(clip_to_shape, draw_command))
             } else {
-                warn!("Invalid clip_to_shape id: {}. The node with this id doesn't exist in the draw tree.", clip_to_shape);
-                0
+                Err(DrawCommandError::InvalidShapeId(clip_to_shape))
             }
         } else {
             // Adding to root — mark root as non-leaf.
             if let Some(root) = self.draw_tree.get_mut(0) {
                 root.set_not_leaf();
             }
-            self.draw_tree.add_child_to_root(draw_command)
+            Ok(self.draw_tree.add_child_to_root(draw_command))
         }
     }
 

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -1,6 +1,6 @@
+use super::types::DrawCommandError;
 use super::*;
 use crate::gradient::types::Fill;
-use super::types::DrawCommandError;
 
 impl<'a> Renderer<'a> {
     pub fn add_shape(

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -74,8 +74,11 @@ impl<'a> Renderer<'a> {
             // Mark the parent as non-leaf since it now has a child.
             if let Some(parent) = self.draw_tree.get_mut(clip_to_shape) {
                 parent.set_not_leaf();
+                self.draw_tree.add_child(clip_to_shape, draw_command)
+            } else {
+                warn!("Invalid clip_to_shape id: {}. The node with this id doesn't exist in the draw tree.", clip_to_shape);
+                0
             }
-            self.draw_tree.add_child(clip_to_shape, draw_command)
         } else {
             // Adding to root — mark root as non-leaf.
             if let Some(root) = self.draw_tree.get_mut(0) {

--- a/src/renderer/rendering.rs
+++ b/src/renderer/rendering.rs
@@ -103,7 +103,7 @@ impl<'a> Renderer<'a> {
                     effect_node_ids.push((node_id, depth));
                 }
             }
-            effect_node_ids.sort_by(|left, right| right.1.cmp(&left.1));
+            effect_node_ids.sort_by_key(|right| std::cmp::Reverse(right.1));
 
             let (width, height) = self.physical_size;
             let physical_size = self.physical_size;

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -181,6 +181,12 @@ impl DrawCommand {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum DrawCommandError {
+    #[error("Shape with id {0} doesn't exist in the draw tree.")]
+    InvalidShapeId(usize),
+}
+
 #[derive(Debug)]
 pub(super) enum TraversalEvent {
     Pre(usize),

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -182,6 +182,7 @@ impl DrawCommand {
 }
 
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum DrawCommandError {
     #[error("Shape with id {0} doesn't exist in the draw tree.")]
     InvalidShapeId(usize),

--- a/tests/visual_regression.rs
+++ b/tests/visual_regression.rs
@@ -92,7 +92,7 @@ fn single_root_no_children() {
     };
 
     let shape = grafo::Shape::rect([(10.0, 10.0), (100.0, 100.0)], grafo::Stroke::default());
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
     renderer.set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)));
 
     let mut pixel_buffer: Vec<u8> = Vec::new();
@@ -117,12 +117,12 @@ fn gradient_fill_basic() {
 
     // Root shape
     let root = Shape::rect([(0.0, 0.0), (100.0, 100.0)], Stroke::default());
-    let root_id = renderer.add_shape(root, None, None);
+    let root_id = renderer.add_shape(root, None, None).unwrap();
     renderer.set_shape_color(root_id, Some(Color::WHITE));
 
     // Gradient child
     let child = Shape::rect([(10.0, 10.0), (90.0, 90.0)], Stroke::default());
-    let child_id = renderer.add_shape(child, Some(root_id), None);
+    let child_id = renderer.add_shape(child, Some(root_id), None).unwrap();
 
     let gradient = Gradient::linear(
         LinearGradientDesc::new(
@@ -181,7 +181,7 @@ fn gradient_survives_pipeline_recreation() {
 
     // Set up a gradient shape.
     let shape = Shape::rect([(10.0, 10.0), (90.0, 90.0)], Stroke::default());
-    let id = renderer.add_shape(shape, None, None);
+    let id = renderer.add_shape(shape, None, None).unwrap();
 
     let gradient = Gradient::linear(
         LinearGradientDesc::new(
@@ -263,24 +263,28 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
     };
 
     // Full-canvas rect root so all children are visible.
-    let root = renderer.add_shape(
-        Shape::rect(
-            [(0.0, 0.0), (CANVAS_WIDTH as f32, CANVAS_HEIGHT as f32)],
-            Stroke::default(),
-        ),
-        None,
-        None,
-    );
+    let root = renderer
+        .add_shape(
+            Shape::rect(
+                [(0.0, 0.0), (CANVAS_WIDTH as f32, CANVAS_HEIGHT as f32)],
+                Stroke::default(),
+            ),
+            None,
+            None,
+        )
+        .unwrap();
     renderer.set_shape_color(root, Some(Color::rgba(0, 0, 0, 0)));
 
     let radii = BorderRadii::new(8.0);
 
     // ── Gradient non-leaf parent (rounded rect → stencil path) ───────────
-    let gradient_parent = renderer.add_shape(
-        Shape::rounded_rect([(10.0, 10.0), (140.0, 90.0)], radii, Stroke::default()),
-        Some(root),
-        None,
-    );
+    let gradient_parent = renderer
+        .add_shape(
+            Shape::rounded_rect([(10.0, 10.0), (140.0, 90.0)], radii, Stroke::default()),
+            Some(root),
+            None,
+        )
+        .unwrap();
 
     let gradient = Gradient::linear(
         LinearGradientDesc::new(
@@ -306,27 +310,33 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
     renderer.set_shape_fill(gradient_parent, Some(Fill::from(gradient)));
 
     // Child of gradient parent (makes it non-leaf → StencilIncrement).
-    let gradient_child = renderer.add_shape(
-        Shape::rect([(20.0, 20.0), (130.0, 80.0)], Stroke::default()),
-        Some(gradient_parent),
-        None,
-    );
+    let gradient_child = renderer
+        .add_shape(
+            Shape::rect([(20.0, 20.0), (130.0, 80.0)], Stroke::default()),
+            Some(gradient_parent),
+            None,
+        )
+        .unwrap();
     renderer.set_shape_color(gradient_child, Some(Color::WHITE));
 
     // ── Solid non-leaf parent (rounded rect → stencil path) ──────────────
-    let solid_parent = renderer.add_shape(
-        Shape::rounded_rect([(160.0, 10.0), (290.0, 90.0)], radii, Stroke::default()),
-        Some(root),
-        None,
-    );
+    let solid_parent = renderer
+        .add_shape(
+            Shape::rounded_rect([(160.0, 10.0), (290.0, 90.0)], radii, Stroke::default()),
+            Some(root),
+            None,
+        )
+        .unwrap();
     renderer.set_shape_color(solid_parent, Some(Color::rgb(0, 200, 0)));
 
     // Child of solid parent (makes it non-leaf → StencilIncrement too).
-    let solid_child = renderer.add_shape(
-        Shape::rect([(170.0, 20.0), (280.0, 80.0)], Stroke::default()),
-        Some(solid_parent),
-        None,
-    );
+    let solid_child = renderer
+        .add_shape(
+            Shape::rect([(170.0, 20.0), (280.0, 80.0)], Stroke::default()),
+            Some(solid_parent),
+            None,
+        )
+        .unwrap();
     renderer.set_shape_color(solid_child, Some(Color::rgb(0, 200, 0)));
 
     // ── Render and verify ─────────────────────────────────────────────────
@@ -361,7 +371,7 @@ fn multi_subpath_fill_has_no_internal_seam() {
         [(0.0, 0.0), (CANVAS_WIDTH as f32, CANVAS_HEIGHT as f32)],
         grafo::Stroke::default(),
     );
-    let canvas_root_id = renderer.add_shape(canvas_root, None, None);
+    let canvas_root_id = renderer.add_shape(canvas_root, None, None).unwrap();
     renderer.set_shape_color(canvas_root_id, Some(grafo::Color::WHITE));
 
     let shape = grafo::Shape::builder()
@@ -374,11 +384,15 @@ fn multi_subpath_fill_has_no_internal_seam() {
         .line_to((10.0, 100.0))
         .close()
         .build();
-    let id = renderer.add_shape(shape, Some(canvas_root_id), None);
+    let id = renderer
+        .add_shape(shape, Some(canvas_root_id), None)
+        .unwrap();
     renderer.set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)));
 
     let rect = grafo::Shape::rect([(140.0, 10.0), (230.0, 100.0)], grafo::Stroke::default());
-    let rect_id = renderer.add_shape(rect, Some(canvas_root_id), None);
+    let rect_id = renderer
+        .add_shape(rect, Some(canvas_root_id), None)
+        .unwrap();
     renderer.set_shape_color(rect_id, Some(grafo::Color::rgb(200, 50, 50)));
 
     let mut pixel_buffer: Vec<u8> = Vec::new();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipping validation so invalid clip targets are detected and surface as errors instead of silently continuing.

* **New Features**
  * Shape-add operations are now fallible and a public error type is exposed for callers to handle.

* **Chores**
  * Examples and tests updated to explicitly handle shape-add results (currently unwrapped), and package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->