### PR TITLE
feat: add errors to draw commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let rect = Shape::rect(
     [(0.0, 0.0), (200.0, 100.0)],
     Stroke::new(2.0, Color::BLACK),
 );
-let id = renderer.add_shape(rect, None, None);
+let id = renderer.add_shape(rect, None, None).unwrap();
 
 // Set per-instance properties
 renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255))).unwrap(); // Blue fill
@@ -86,7 +86,7 @@ let id = renderer.add_shape(
     Shape::rect([(0.0,0.0),(300.0,200.0)], Stroke::new(1.0, Color::BLACK)),
     None,
     None,
-);
+).unwrap();
 renderer.set_shape_color(id, Some(Color::rgb(40, 40, 40))).unwrap(); // base color under textures
 renderer.set_shape_texture_on(id, TextureLayer::Background, Some(bg_tex_id)).unwrap();
 renderer.set_shape_texture_on(id, TextureLayer::Foreground, Some(fg_tex_id)).unwrap();
@@ -110,7 +110,7 @@ Use per-shape transforms to position shapes. Common helpers:
 Example:
 
 ```rust
-let id = renderer.add_shape(my_shape, None, None);
+let id = renderer.add_shape(my_shape, None, None).unwrap();
 let r = grafo::TransformInstance::rotation_z_deg(15.0);
 let t = grafo::TransformInstance::translation(150.0, 80.0);
 // Rotate first, then translate

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ let rect = Shape::rect(
 let id = renderer.add_shape(rect, None, None);
 
 // Set per-instance properties
-renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255))); // Blue fill
-renderer.set_shape_transform(id, grafo::TransformInstance::translation(100.0, 100.0));
+renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255))).unwrap(); // Blue fill
+renderer.set_shape_transform(id, grafo::TransformInstance::translation(100.0, 100.0)).unwrap();
 
 // Render one frame (typical winit loop would call this on RedrawRequested)
 renderer.render().unwrap();
@@ -87,13 +87,13 @@ let id = renderer.add_shape(
     None,
     None,
 );
-renderer.set_shape_color(id, Some(Color::rgb(40, 40, 40))); // base color under textures
-renderer.set_shape_texture_on(id, TextureLayer::Background, Some(bg_tex_id));
-renderer.set_shape_texture_on(id, TextureLayer::Foreground, Some(fg_tex_id));
+renderer.set_shape_color(id, Some(Color::rgb(40, 40, 40))).unwrap(); // base color under textures
+renderer.set_shape_texture_on(id, TextureLayer::Background, Some(bg_tex_id)).unwrap();
+renderer.set_shape_texture_on(id, TextureLayer::Foreground, Some(fg_tex_id)).unwrap();
 
 // Single-layer helper (Background):
-renderer.set_shape_texture(id, Some(bg_tex_id));
-renderer.set_shape_color(id, Some(Color::WHITE)); // useful when texture transparency should reveal white
+renderer.set_shape_texture(id, Some(bg_tex_id)).unwrap();
+renderer.set_shape_color(id, Some(Color::WHITE)).unwrap(); // useful when texture transparency should reveal white
 ```
 
 See `examples/multi_texture.rs` for a runnable demo that generates procedural background & foreground textures.
@@ -114,7 +114,7 @@ let id = renderer.add_shape(my_shape, None, None);
 let r = grafo::TransformInstance::rotation_z_deg(15.0);
 let t = grafo::TransformInstance::translation(150.0, 80.0);
 // Rotate first, then translate
-renderer.set_shape_transform(id, r.then(&t));
+renderer.set_shape_transform(id, r.then(&t)).unwrap();
 ```
 
 ## Documentation

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -157,7 +157,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let bg_id = renderer.add_shape(bg, None, None).unwrap();
-                renderer.set_shape_color(bg_id, Some(Color::rgb(245, 245, 250)));
+                renderer
+                    .set_shape_color(bg_id, Some(Color::rgb(245, 245, 250)))
+                    .unwrap();
 
                 // Colorful rectangles that will be visible through the panel
                 let r1 = Shape::rect(
@@ -165,28 +167,36 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
                 let r1_id = renderer.add_shape(r1, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)));
+                renderer
+                    .set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)))
+                    .unwrap();
 
                 let r2 = Shape::rect(
                     [(180.0, 160.0), (420.0, 380.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
                 let r2_id = renderer.add_shape(r2, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)));
+                renderer
+                    .set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)))
+                    .unwrap();
 
                 let r3 = Shape::rect(
                     [(340.0, 100.0), (560.0, 300.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
                 let r3_id = renderer.add_shape(r3, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)));
+                renderer
+                    .set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)))
+                    .unwrap();
 
                 let r4 = Shape::rect(
                     [(100.0, 350.0), (700.0, 540.0)],
                     Stroke::new(2.0, Color::rgb(0, 0, 0)),
                 );
                 let r4_id = renderer.add_shape(r4, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)));
+                renderer
+                    .set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)))
+                    .unwrap();
 
                 // ── Frosted-glass panel with backdrop blur ───────────────
                 // This shape is rendered on top; the backdrop effect blurs
@@ -197,7 +207,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 );
                 let panel_id = renderer.add_shape(panel, None, None).unwrap();
                 // Semi-transparent white so the blurred background shows through
-                renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 100)));
+                renderer
+                    .set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 100)))
+                    .unwrap();
 
                 // To test that clipping works correctly with the blur
                 let panel_content = Shape::rounded_rect(
@@ -208,7 +220,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 let content_id = renderer
                     .add_shape(panel_content, Some(panel_id), None)
                     .unwrap();
-                renderer.set_shape_color(content_id, Some(Color::rgba(200, 220, 255, 120)));
+                renderer
+                    .set_shape_color(content_id, Some(Color::rgba(200, 220, 255, 120)))
+                    .unwrap();
 
                 let blur_params = BlurParams {
                     radius: 12.0,
@@ -229,7 +243,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::rgb(80, 80, 80)),
                 );
                 let panel2_id = renderer.add_shape(panel2, None, None).unwrap();
-                renderer.set_shape_color(panel2_id, Some(Color::rgba(200, 220, 255, 120)));
+                renderer
+                    .set_shape_color(panel2_id, Some(Color::rgba(200, 220, 255, 120)))
+                    .unwrap();
 
                 let blur_params2 = BlurParams {
                     radius: 20.0,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -41,7 +41,9 @@ impl<'a> ApplicationHandler for App<'a> {
             Stroke::new(2.0, Color::BLACK),
         );
         let id = renderer.add_shape(rect, None, None).unwrap();
-        renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
+        renderer
+            .set_shape_color(id, Some(Color::rgb(0, 128, 255)))
+            .unwrap();
 
         self.window = Some(window);
         self.renderer = Some(renderer);
@@ -76,14 +78,18 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let id = renderer.add_shape(rect, None, None).unwrap();
-                renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
+                renderer
+                    .set_shape_color(id, Some(Color::rgb(0, 128, 255)))
+                    .unwrap();
 
                 let rect = Shape::rect(
                     [(500.0, 100.0), (600.0, 200.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let id2 = renderer.add_shape(rect, None, None).unwrap();
-                renderer.set_shape_color(id2, Some(Color::rgb(0, 128, 0)));
+                renderer
+                    .set_shape_color(id2, Some(Color::rgb(0, 128, 0)))
+                    .unwrap();
 
                 match renderer.render() {
                     Ok(_) => {

--- a/examples/bench_render_loop.rs
+++ b/examples/bench_render_loop.rs
@@ -124,22 +124,29 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
         let container_id = renderer
             .add_cached_shape_to_the_render_queue(CACHE_KEY_CONTAINER, None)
             .unwrap();
-        renderer.set_shape_color(
-            container_id,
-            Some(container_colors[c % container_colors.len()]),
-        );
+        renderer
+            .set_shape_color(
+                container_id,
+                Some(container_colors[c % container_colors.len()]),
+            )
+            .unwrap();
         let cx = 10.0 + c as f32 * 250.0;
-        renderer.set_shape_transform(container_id, TransformInstance::translation(cx, 10.0));
+        renderer
+            .set_shape_transform(container_id, TransformInstance::translation(cx, 10.0))
+            .unwrap();
         total_shapes += 1;
 
         for r in 0..ROWS_PER_CONTAINER {
             let row_id = renderer
                 .add_cached_shape_to_the_render_queue(CACHE_KEY_ROW, Some(container_id))
                 .unwrap();
-            renderer.set_shape_color(row_id, Some(Color::rgb(200, 200, 210)));
+            renderer
+                .set_shape_color(row_id, Some(Color::rgb(200, 200, 210)))
+                .unwrap();
             let ry = 10.0 + r as f32 * 120.0;
             renderer
-                .set_shape_transform(row_id, TransformInstance::translation(cx + 10.0, 10.0 + ry));
+                .set_shape_transform(row_id, TransformInstance::translation(cx + 10.0, 10.0 + ry))
+                .unwrap();
             total_shapes += 1;
 
             for cell in 0..CELLS_PER_ROW {
@@ -147,13 +154,17 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
                     .add_cached_shape_to_the_render_queue(CACHE_KEY_CELL, Some(row_id))
                     .unwrap();
                 let brightness = (100u8).saturating_add((cell * 30) as u8);
-                renderer.set_shape_color(
-                    cell_id,
-                    Some(Color::rgb(brightness, brightness, brightness)),
-                );
+                renderer
+                    .set_shape_color(
+                        cell_id,
+                        Some(Color::rgb(brightness, brightness, brightness)),
+                    )
+                    .unwrap();
                 let cellx = cx + 20.0 + cell as f32 * 42.0;
                 let celly = 20.0 + ry + 10.0;
-                renderer.set_shape_transform(cell_id, TransformInstance::translation(cellx, celly));
+                renderer
+                    .set_shape_transform(cell_id, TransformInstance::translation(cellx, celly))
+                    .unwrap();
                 total_shapes += 1;
             }
         }
@@ -164,19 +175,27 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
     let sidebar_id = renderer
         .add_cached_shape_to_the_render_queue(CACHE_KEY_SIDEBAR, None)
         .unwrap();
-    renderer.set_shape_color(sidebar_id, Some(Color::rgb(50, 50, 70)));
-    renderer.set_shape_transform(sidebar_id, TransformInstance::translation(sidebar_x, 10.0));
+    renderer
+        .set_shape_color(sidebar_id, Some(Color::rgb(50, 50, 70)))
+        .unwrap();
+    renderer
+        .set_shape_transform(sidebar_id, TransformInstance::translation(sidebar_x, 10.0))
+        .unwrap();
     total_shapes += 1;
 
     for i in 0..CIRCLES_IN_SIDEBAR {
         let circle_id = renderer
             .add_cached_shape_to_the_render_queue(CACHE_KEY_CIRCLE, Some(sidebar_id))
             .unwrap();
-        renderer.set_shape_color(circle_id, Some(Color::rgb(220, 180, 50)));
-        renderer.set_shape_transform(
-            circle_id,
-            TransformInstance::translation(sidebar_x + 30.0, 30.0 + i as f32 * 60.0),
-        );
+        renderer
+            .set_shape_color(circle_id, Some(Color::rgb(220, 180, 50)))
+            .unwrap();
+        renderer
+            .set_shape_transform(
+                circle_id,
+                TransformInstance::translation(sidebar_x + 30.0, 30.0 + i as f32 * 60.0),
+            )
+            .unwrap();
         total_shapes += 1;
     }
 
@@ -186,13 +205,17 @@ fn build_scene(renderer: &mut grafo::Renderer<'_>) -> usize {
         let tex_id = renderer
             .add_cached_shape_to_the_render_queue(CACHE_KEY_TEXTURED, None)
             .unwrap();
-        renderer.set_shape_texture(tex_id, Some(TEXTURE_ID_BASE + i as u64));
+        renderer
+            .set_shape_texture(tex_id, Some(TEXTURE_ID_BASE + i as u64))
+            .unwrap();
         let col = i % 5;
         let row = i / 5;
         // Overlap: offset by 220px instead of 250px so they overlap by 30px
         let tx = 10.0 + col as f32 * 220.0;
         let ty = 520.0 + row as f32 * 220.0;
-        renderer.set_shape_transform(tex_id, TransformInstance::translation(tx, ty));
+        renderer
+            .set_shape_transform(tex_id, TransformInstance::translation(tx, ty))
+            .unwrap();
         total_shapes += 1;
     }
 

--- a/examples/box_shadow.rs
+++ b/examples/box_shadow.rs
@@ -74,7 +74,7 @@ fn draw_card(
         Stroke::new(0.0, Color::TRANSPARENT),
     );
     let card = renderer.add_shape(card_shape, None, None).unwrap();
-    renderer.set_shape_color(card, Some(card_color));
+    renderer.set_shape_color(card, Some(card_color)).unwrap();
 
     let params = BoxShadowParams {
         box_min: [x, y],
@@ -245,7 +245,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 let scene_bg =
                     Shape::rect([(0.0, 0.0), (pw, ph)], Stroke::new(0.0, Color::TRANSPARENT));
                 let bg_id = renderer.add_shape(scene_bg, None, None).unwrap();
-                renderer.set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)));
+                renderer
+                    .set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)))
+                    .unwrap();
 
                 let vp = (pw, ph);
 

--- a/examples/gaussian_blur.rs
+++ b/examples/gaussian_blur.rs
@@ -154,7 +154,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let bg_id = renderer.add_shape(bg, None, None).unwrap();
-                renderer.set_shape_color(bg_id, Some(Color::rgb(240, 240, 245)));
+                renderer
+                    .set_shape_color(bg_id, Some(Color::rgb(240, 240, 245)))
+                    .unwrap();
 
                 // ── Label text (just a thin rectangle as a visual marker) ─
                 let label = Shape::rect(
@@ -162,7 +164,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::BLACK),
                 );
                 let l = renderer.add_shape(label, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(l, Some(Color::rgb(200, 200, 255)));
+                renderer
+                    .set_shape_color(l, Some(Color::rgb(200, 200, 255)))
+                    .unwrap();
 
                 // ── Blurred group ────────────────────────────────────────
                 // Parent shape defines the group boundary
@@ -171,7 +175,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
                 let group = renderer.add_shape(group_bg, None, None).unwrap();
-                renderer.set_shape_color(group, Some(Color::rgba(255, 100, 100, 100)));
+                renderer
+                    .set_shape_color(group, Some(Color::rgba(255, 100, 100, 100)))
+                    .unwrap();
 
                 // Child shapes inside the group
                 let child1 = Shape::rect(
@@ -179,14 +185,18 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
                 let c1 = renderer.add_shape(child1, Some(group), None).unwrap();
-                renderer.set_shape_color(c1, Some(Color::rgb(50, 120, 255)));
+                renderer
+                    .set_shape_color(c1, Some(Color::rgb(50, 120, 255)))
+                    .unwrap();
 
                 let child2 = Shape::rect(
                     [(200.0, 180.0), (450.0, 360.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
                 let c2 = renderer.add_shape(child2, Some(group), None).unwrap();
-                renderer.set_shape_color(c2, Some(Color::rgb(50, 220, 80)));
+                renderer
+                    .set_shape_color(c2, Some(Color::rgb(50, 220, 80)))
+                    .unwrap();
 
                 // Attach the blur effect with radius = 8 pixels
                 let blur_params = BlurParams {
@@ -204,21 +214,27 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
                 let sharp = renderer.add_shape(sharp_bg, None, None).unwrap();
-                renderer.set_shape_color(sharp, Some(Color::rgb(255, 100, 100)));
+                renderer
+                    .set_shape_color(sharp, Some(Color::rgb(255, 100, 100)))
+                    .unwrap();
 
                 let sc1 = Shape::rect(
                     [(100.0, 430.0), (300.0, 550.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
                 let s1 = renderer.add_shape(sc1, Some(sharp), None).unwrap();
-                renderer.set_shape_color(s1, Some(Color::rgb(50, 120, 255)));
+                renderer
+                    .set_shape_color(s1, Some(Color::rgb(50, 120, 255)))
+                    .unwrap();
 
                 let sc2 = Shape::rect(
                     [(200.0, 440.0), (450.0, 550.0)],
                     Stroke::new(3.0, Color::rgb(0, 0, 0)),
                 );
                 let s2 = renderer.add_shape(sc2, Some(sharp), None).unwrap();
-                renderer.set_shape_color(s2, Some(Color::rgb(50, 220, 80)));
+                renderer
+                    .set_shape_color(s2, Some(Color::rgb(50, 220, 80)))
+                    .unwrap();
 
                 // ── Render ───────────────────────────────────────────────
                 match renderer.render() {

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -103,7 +103,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let bg_id = renderer.add_shape(bg, None, None).unwrap();
-                renderer.set_shape_color(bg_id, Some(Color::rgb(200, 200, 220)));
+                renderer
+                    .set_shape_color(bg_id, Some(Color::rgb(200, 200, 220)))
+                    .unwrap();
 
                 // ── Group 1: 50% opacity ─────────────────────────────────
                 let group1_bg = Shape::rect(
@@ -111,7 +113,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
                 let group1 = renderer.add_shape(group1_bg, None, None).unwrap();
-                renderer.set_shape_color(group1, Some(Color::rgb(255, 100, 100)));
+                renderer
+                    .set_shape_color(group1, Some(Color::rgb(255, 100, 100)))
+                    .unwrap();
 
                 // Child 1: overlapping blue rectangle
                 let child1 = Shape::rect(
@@ -119,7 +123,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let c1 = renderer.add_shape(child1, Some(group1), None).unwrap();
-                renderer.set_shape_color(c1, Some(Color::rgb(50, 100, 255)));
+                renderer
+                    .set_shape_color(c1, Some(Color::rgb(50, 100, 255)))
+                    .unwrap();
 
                 // Child 2: overlapping green rectangle
                 let child2 = Shape::rect(
@@ -127,7 +133,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let c2 = renderer.add_shape(child2, Some(group1), None).unwrap();
-                renderer.set_shape_color(c2, Some(Color::rgb(50, 200, 50)));
+                renderer
+                    .set_shape_color(c2, Some(Color::rgb(50, 200, 50)))
+                    .unwrap();
 
                 // Attach 50% opacity to group1
                 let opacity: f32 = 0.5;
@@ -141,14 +149,18 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(0.0, Color::TRANSPARENT),
                 );
                 let group2 = renderer.add_shape(group2_bg, None, None).unwrap();
-                renderer.set_shape_color(group2, Some(Color::rgb(255, 200, 50)));
+                renderer
+                    .set_shape_color(group2, Some(Color::rgb(255, 200, 50)))
+                    .unwrap();
 
                 let child3 = Shape::rect(
                     [(370.0, 130.0), (680.0, 320.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let c3 = renderer.add_shape(child3, Some(group2), None).unwrap();
-                renderer.set_shape_color(c3, Some(Color::rgb(128, 0, 200)));
+                renderer
+                    .set_shape_color(c3, Some(Color::rgb(128, 0, 200)))
+                    .unwrap();
 
                 let opacity2: f32 = 0.8;
                 renderer

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -105,7 +105,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::rgb(255, 0, 0)),
                 );
                 let back_id = renderer.add_shape(background, None, None).unwrap();
-                renderer.set_shape_color(back_id, Some(Color::BLACK));
+                renderer
+                    .set_shape_color(back_id, Some(Color::BLACK))
+                    .unwrap();
 
                 // Draw a triangle — diagonal edges show aliasing clearly
                 let triangle = Shape::builder()
@@ -116,7 +118,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     .close()
                     .build();
                 let id = renderer.add_shape(triangle, Some(0), None).unwrap();
-                renderer.set_shape_color(id, Some(Color::rgb(0, 128, 255)));
+                renderer
+                    .set_shape_color(id, Some(Color::rgb(0, 128, 255)))
+                    .unwrap();
 
                 // Draw a rounded rectangle — curved edges benefit from MSAA
                 let rounded_rect = Shape::rounded_rect(
@@ -125,7 +129,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::rgb(255, 0, 0)),
                 );
                 let id2 = renderer.add_shape(rounded_rect, Some(0), None).unwrap();
-                renderer.set_shape_color(id2, Some(Color::rgb(255, 100, 50)));
+                renderer
+                    .set_shape_color(id2, Some(Color::rgb(255, 100, 50)))
+                    .unwrap();
 
                 // Draw a circle (approximated with a rounded rect)
                 let circle = Shape::rounded_rect(
@@ -134,7 +140,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let id3 = renderer.add_shape(circle, Some(0), None).unwrap();
-                renderer.set_shape_color(id3, Some(Color::rgb(50, 200, 100)));
+                renderer
+                    .set_shape_color(id3, Some(Color::rgb(50, 200, 100)))
+                    .unwrap();
 
                 // Draw a small detailed shape - thin diagonal lines are great for MSAA testing
                 let small_rect = Shape::rect(
@@ -142,7 +150,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(100, 0, 150)),
                 );
                 let id4 = renderer.add_shape(small_rect, None, None).unwrap();
-                renderer.set_shape_color(id4, Some(Color::rgb(200, 200, 255)));
+                renderer
+                    .set_shape_color(id4, Some(Color::rgb(200, 200, 255)))
+                    .unwrap();
 
                 match renderer.render() {
                     Ok(_) => {

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -54,7 +54,9 @@ impl ApplicationHandler for App {
                 None,
             )
             .unwrap();
-        renderer.set_shape_color(shape_id, Some(Color::rgb(200, 200, 200)));
+        renderer
+            .set_shape_color(shape_id, Some(Color::rgb(200, 200, 200)))
+            .unwrap();
 
         // Allocate two textures (background checker, foreground circle mask for demo)
         let tex_mgr = renderer.texture_manager();
@@ -100,8 +102,12 @@ impl ApplicationHandler for App {
         tex_mgr.allocate_texture_with_data(self.fg_tex_id, (w, h), &fg);
 
         // Assign textures to background + foreground layers
-        renderer.set_shape_texture_on(shape_id, TextureLayer::Background, Some(self.bg_tex_id));
-        renderer.set_shape_texture_on(shape_id, TextureLayer::Foreground, Some(self.fg_tex_id));
+        renderer
+            .set_shape_texture_on(shape_id, TextureLayer::Background, Some(self.bg_tex_id))
+            .unwrap();
+        renderer
+            .set_shape_texture_on(shape_id, TextureLayer::Foreground, Some(self.fg_tex_id))
+            .unwrap();
 
         self.shape_id = Some(shape_id);
         self.renderer = Some(renderer);

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -231,7 +231,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 let scene_bg =
                     Shape::rect([(0.0, 0.0), (pw, ph)], Stroke::new(0.0, Color::TRANSPARENT));
                 let bg_id = renderer.add_shape(scene_bg, None, None).unwrap();
-                renderer.set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)));
+                renderer
+                    .set_shape_color(bg_id, Some(Color::rgb(235, 235, 240)))
+                    .unwrap();
 
                 // ── Colorful background content (for the blur to act on) ─
                 let r1 = Shape::rect(
@@ -239,28 +241,36 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let r1_id = renderer.add_shape(r1, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)));
+                renderer
+                    .set_shape_color(r1_id, Some(Color::rgb(220, 50, 50)))
+                    .unwrap();
 
                 let r2 = Shape::rect(
                     [(200.0, 150.0), (500.0, 400.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let r2_id = renderer.add_shape(r2, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)));
+                renderer
+                    .set_shape_color(r2_id, Some(Color::rgb(50, 160, 50)))
+                    .unwrap();
 
                 let r3 = Shape::rect(
                     [(400.0, 80.0), (700.0, 320.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let r3_id = renderer.add_shape(r3, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)));
+                renderer
+                    .set_shape_color(r3_id, Some(Color::rgb(50, 80, 220)))
+                    .unwrap();
 
                 let r4 = Shape::rect(
                     [(100.0, 380.0), (650.0, 550.0)],
                     Stroke::new(2.0, Color::BLACK),
                 );
                 let r4_id = renderer.add_shape(r4, Some(bg_id), None).unwrap();
-                renderer.set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)));
+                renderer
+                    .set_shape_color(r4_id, Some(Color::rgb(200, 180, 50)))
+                    .unwrap();
 
                 // ── Panel: parent with box shadow (group effect) ─────────
                 // The parent is transparent — it exists to carry the box
@@ -279,7 +289,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 let panel = renderer.add_shape(panel_shape, None, None).unwrap();
                 // Fully transparent — the visual fill comes from the child
                 // with the backdrop blur. The parent only contributes the shadow.
-                renderer.set_shape_color(panel, Some(Color::TRANSPARENT));
+                renderer
+                    .set_shape_color(panel, Some(Color::TRANSPARENT))
+                    .unwrap();
 
                 // Attach box shadow as a group effect on the parent
                 let shadow_params = BoxShadowParams {
@@ -308,7 +320,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 );
                 let glass = renderer.add_shape(glass_shape, Some(panel), None).unwrap();
                 // Semi-transparent white tint over the blurred background
-                renderer.set_shape_color(glass, Some(Color::rgba(255, 255, 255, 60)));
+                renderer
+                    .set_shape_color(glass, Some(Color::rgba(255, 255, 255, 60)))
+                    .unwrap();
 
                 // Attach backdrop blur on the child
                 let blur_params = BlurParams {

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -97,7 +97,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(0.0, Color::rgb(0, 0, 0)),
                 );
                 let background_id = renderer.add_shape(background, None, None).unwrap();
-                renderer.set_shape_color(background_id, Some(Color::rgb(30, 30, 30)));
+                renderer
+                    .set_shape_color(background_id, Some(Color::rgb(30, 30, 30)))
+                    .unwrap();
 
                 // A white rounded rect that we will texture
                 let textured_rect = Shape::rounded_rect(
@@ -108,12 +110,16 @@ impl<'a> ApplicationHandler for App<'a> {
                 let rect_id = renderer
                     .add_shape(textured_rect, Some(background_id), None)
                     .unwrap();
-                renderer.set_shape_color(rect_id, Some(Color::rgb(255, 255, 255))); // white so texture shows un-tinted
-                                                                                    // Previously this shape used an offset of (100, 100)
-                renderer.set_shape_transform(
-                    rect_id,
-                    grafo::TransformInstance::translation(100.0, 100.0),
-                );
+                renderer
+                    .set_shape_color(rect_id, Some(Color::rgb(255, 255, 255)))
+                    .unwrap(); // white so texture shows un-tinted
+                               // Previously this shape used an offset of (100, 100)
+                renderer
+                    .set_shape_transform(
+                        rect_id,
+                        grafo::TransformInstance::translation(100.0, 100.0),
+                    )
+                    .unwrap();
 
                 // Upload texture once per frame here for demo purposes. In a real app, do this once.
                 let texture_id = 100u64;
@@ -130,7 +136,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     .unwrap();
 
                 // Associate the uploaded texture with our shape
-                renderer.set_shape_texture(rect_id, Some(texture_id));
+                renderer
+                    .set_shape_texture(rect_id, Some(texture_id))
+                    .unwrap();
 
                 let timer = Instant::now();
                 match renderer.render() {

--- a/examples/star_wars_tilt.rs
+++ b/examples/star_wars_tilt.rs
@@ -93,7 +93,9 @@ impl<'a> ApplicationHandler for App<'a> {
                                 None,
                             )
                             .unwrap();
-                        renderer.set_shape_color(background, Some(Color::rgb(30, 30, 30)));
+                        renderer
+                            .set_shape_color(background, Some(Color::rgb(30, 30, 30)))
+                            .unwrap();
 
                         // Create a 100x100 rectangle (matching the HTML)
                         // Gold color (#FFD700 = rgb(255, 215, 0)) with white border (2px)
@@ -105,7 +107,9 @@ impl<'a> ApplicationHandler for App<'a> {
                         let rect_id = renderer.add_shape(rect_shape, None, None).unwrap();
 
                         // Set the fill color to gold
-                        renderer.set_shape_color(rect_id, Some(Color::TRANSPARENT));
+                        renderer
+                            .set_shape_color(rect_id, Some(Color::TRANSPARENT))
+                            .unwrap();
 
                         self.rect_id = Some(rect_id);
 
@@ -116,13 +120,17 @@ impl<'a> ApplicationHandler for App<'a> {
                         let inner_rect_1 = renderer
                             .add_shape(inner_rect_shape.clone(), None, None)
                             .unwrap();
-                        renderer.set_shape_color(inner_rect_1, Some(Color::rgb(125, 0, 0)));
+                        renderer
+                            .set_shape_color(inner_rect_1, Some(Color::rgb(125, 0, 0)))
+                            .unwrap();
                         self.inner_rect_1 = Some(inner_rect_1);
 
                         // TODO: clip
                         let inner_rect_2 =
                             renderer.add_shape(inner_rect_shape, None, None).unwrap();
-                        renderer.set_shape_color(inner_rect_2, Some(Color::rgb(0, 125, 0)));
+                        renderer
+                            .set_shape_color(inner_rect_2, Some(Color::rgb(0, 125, 0)))
+                            .unwrap();
                         self.inner_rect_2 = Some(inner_rect_2);
                     }
 
@@ -168,7 +176,9 @@ impl<'a> ApplicationHandler for App<'a> {
                         .with_origin(50.0, 50.0)
                         .compose_2(&transformator::Transform::new());
 
-                    renderer.set_shape_transform_cols(rect_id, parent_local.rows_world());
+                    renderer
+                        .set_shape_transform_cols(rect_id, parent_local.rows_world())
+                        .unwrap();
 
                     // Inner rectangles inherit parent transform and sit inside with 10px padding.
                     // Layout: padding(10) + rect(35) + gap(10) + rect(35) + padding(10) = 100 total width.
@@ -179,14 +189,18 @@ impl<'a> ApplicationHandler for App<'a> {
                         .then_rotate_y_deg(20.0)
                         .with_origin(17.5, 40.0)
                         .compose_2(&parent_local);
-                    renderer.set_shape_transform_cols(inner_rect_1, child1.rows_world());
+                    renderer
+                        .set_shape_transform_cols(inner_rect_1, child1.rows_world())
+                        .unwrap();
 
                     let child2 = transformator::Transform::new()
                         .with_position_relative_to_parent(55.0, 10.0)
                         .then_rotate_y_deg(20.0)
                         .with_origin(17.5, 40.0)
                         .compose_2(&parent_local);
-                    renderer.set_shape_transform_cols(inner_rect_2, child2.rows_world());
+                    renderer
+                        .set_shape_transform_cols(inner_rect_2, child2.rows_world())
+                        .unwrap();
 
                     // Hit testing: transform mouse position to local coordinates for each shape
                     // Check children first (they're on top)
@@ -223,26 +237,38 @@ impl<'a> ApplicationHandler for App<'a> {
 
                     // Update colors based on hover state
                     if self.parent_hovered {
-                        renderer.set_shape_color(rect_id, Some(Color::rgba(255, 235, 100, 200)));
+                        renderer
+                            .set_shape_color(rect_id, Some(Color::rgba(255, 235, 100, 200)))
+                            .unwrap();
                     // Brighter gold
                     } else {
-                        renderer.set_shape_color(rect_id, Some(Color::rgba(255, 215, 0, 200)));
+                        renderer
+                            .set_shape_color(rect_id, Some(Color::rgba(255, 215, 0, 200)))
+                            .unwrap();
                         // Normal gold
                     }
 
                     if self.child1_hovered {
-                        renderer.set_shape_color(inner_rect_1, Some(Color::rgb(200, 50, 50)));
+                        renderer
+                            .set_shape_color(inner_rect_1, Some(Color::rgb(200, 50, 50)))
+                            .unwrap();
                     // Brighter red
                     } else {
-                        renderer.set_shape_color(inner_rect_1, Some(Color::rgb(125, 0, 0)));
+                        renderer
+                            .set_shape_color(inner_rect_1, Some(Color::rgb(125, 0, 0)))
+                            .unwrap();
                         // Normal red
                     }
 
                     if self.child2_hovered {
-                        renderer.set_shape_color(inner_rect_2, Some(Color::rgb(50, 200, 50)));
+                        renderer
+                            .set_shape_color(inner_rect_2, Some(Color::rgb(50, 200, 50)))
+                            .unwrap();
                     // Brighter green
                     } else {
-                        renderer.set_shape_color(inner_rect_2, Some(Color::rgb(0, 125, 0)));
+                        renderer
+                            .set_shape_color(inner_rect_2, Some(Color::rgb(0, 125, 0)))
+                            .unwrap();
                         // Normal green
                     }
 

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -346,7 +346,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let background_id = renderer.add_shape(background, None, None).unwrap();
-                renderer.set_shape_color(background_id, Some(Color::BLACK));
+                renderer
+                    .set_shape_color(background_id, Some(Color::BLACK))
+                    .unwrap();
 
                 // Compute transforms in euclid space (same as before)
                 let red_tx = Transform3D::rotation(0.0, 0.0, 1.0, Angle::degrees(45.0))
@@ -487,67 +489,93 @@ impl<'a> ApplicationHandler for App<'a> {
                 let perspective = renderer.add_shape(perspective_shape, None, None).unwrap();
 
                 // Set per-instance colors
-                renderer.set_shape_color(
-                    red,
-                    Some(if red_hover {
-                        self.red_color.1
-                    } else {
-                        self.red_color.0
-                    }),
-                );
-                renderer.set_shape_color(
-                    green,
-                    Some(if green_hover {
-                        self.green_color.1
-                    } else {
-                        self.green_color.0
-                    }),
-                );
-                renderer.set_shape_color(
-                    blue,
-                    Some(if blue_hover {
-                        self.blue_color.1
-                    } else {
-                        self.blue_color.0
-                    }),
-                );
-                renderer.set_shape_color(
-                    jelly,
-                    Some(if jelly_hover {
-                        self.jelly_color.1
-                    } else {
-                        self.jelly_color.0
-                    }),
-                );
-                renderer.set_shape_color(
-                    heart,
-                    Some(if heart_hover {
-                        self.heart_color.1
-                    } else {
-                        self.heart_color.0
-                    }),
-                );
-                renderer.set_shape_color(
-                    perspective,
-                    Some(if perspective_hover {
-                        self.perspective_color.1
-                    } else {
-                        self.perspective_color.0
-                    }),
-                );
+                renderer
+                    .set_shape_color(
+                        red,
+                        Some(if red_hover {
+                            self.red_color.1
+                        } else {
+                            self.red_color.0
+                        }),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_color(
+                        green,
+                        Some(if green_hover {
+                            self.green_color.1
+                        } else {
+                            self.green_color.0
+                        }),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_color(
+                        blue,
+                        Some(if blue_hover {
+                            self.blue_color.1
+                        } else {
+                            self.blue_color.0
+                        }),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_color(
+                        jelly,
+                        Some(if jelly_hover {
+                            self.jelly_color.1
+                        } else {
+                            self.jelly_color.0
+                        }),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_color(
+                        heart,
+                        Some(if heart_hover {
+                            self.heart_color.1
+                        } else {
+                            self.heart_color.0
+                        }),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_color(
+                        perspective,
+                        Some(if perspective_hover {
+                            self.perspective_color.1
+                        } else {
+                            self.perspective_color.0
+                        }),
+                    )
+                    .unwrap();
 
                 // Give the blue shape a texture
-                renderer.set_shape_texture(blue, Some(self.rust_logo_texture_id));
+                renderer
+                    .set_shape_texture(blue, Some(self.rust_logo_texture_id))
+                    .unwrap();
 
-                renderer.set_shape_transform(red, transform_instance_from_euclid(red_tx));
-                renderer.set_shape_transform(green, transform_instance_from_euclid(green_tx));
-                renderer.set_shape_transform(blue, transform_instance_from_euclid(blue_tx));
-                renderer.set_shape_transform(jelly, transform_instance_from_euclid(jelly_tx));
-                renderer.set_shape_transform(heart, transform_instance_from_euclid(heart_tx));
-                renderer.set_shape_transform(
-                    perspective,
-                    transform_instance_from_euclid(perspective_tx),
-                );
+                renderer
+                    .set_shape_transform(red, transform_instance_from_euclid(red_tx))
+                    .unwrap();
+                renderer
+                    .set_shape_transform(green, transform_instance_from_euclid(green_tx))
+                    .unwrap();
+                renderer
+                    .set_shape_transform(blue, transform_instance_from_euclid(blue_tx))
+                    .unwrap();
+                renderer
+                    .set_shape_transform(jelly, transform_instance_from_euclid(jelly_tx))
+                    .unwrap();
+                renderer
+                    .set_shape_transform(heart, transform_instance_from_euclid(heart_tx))
+                    .unwrap();
+                renderer
+                    .set_shape_transform(
+                        perspective,
+                        transform_instance_from_euclid(perspective_tx),
+                    )
+                    .unwrap();
 
                 // Advance animation angle
                 self.angle = (self.angle + 0.02) % (std::f32::consts::TAU);

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -102,7 +102,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let background_id = renderer.add_shape(background, None, None).unwrap();
-                renderer.set_shape_color(background_id, Some(Color::rgb(255, 255, 200)));
+                renderer
+                    .set_shape_color(background_id, Some(Color::rgb(255, 255, 200)))
+                    .unwrap();
 
                 let red = Shape::rounded_rect(
                     [(0.0, 0.0), (200.0, 200.0)],
@@ -110,7 +112,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let red_id = renderer.add_shape(red, Some(background_id), None).unwrap();
-                renderer.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
+                renderer
+                    .set_shape_color(red_id, Some(Color::rgb(255, 0, 0)))
+                    .unwrap();
 
                 let green = Shape::rounded_rect(
                     [(0.0, 0.0), (200.0, 200.0)],
@@ -118,7 +122,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let green_id = renderer.add_shape(green, Some(red_id), None).unwrap();
-                renderer.set_shape_color(green_id, Some(Color::rgb(0, 255, 0)));
+                renderer
+                    .set_shape_color(green_id, Some(Color::rgb(0, 255, 0)))
+                    .unwrap();
 
                 let blue = Shape::rounded_rect(
                     [(0.0, 0.0), (200.0, 200.0)],
@@ -126,7 +132,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let blue_id = renderer.add_shape(blue, Some(green_id), None).unwrap();
-                renderer.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
+                renderer
+                    .set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)))
+                    .unwrap();
 
                 let yellow = Shape::rounded_rect(
                     [(0.0, 0.0), (150.0, 150.0)],
@@ -134,7 +142,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let yellow_id = renderer.add_shape(yellow, Some(green_id), None).unwrap();
-                renderer.set_shape_color(yellow_id, Some(Color::rgb(255, 255, 0)));
+                renderer
+                    .set_shape_color(yellow_id, Some(Color::rgb(255, 255, 0)))
+                    .unwrap();
 
                 let white = Shape::rounded_rect(
                     [(0.0, 0.0), (20.0, 20.0)],
@@ -142,7 +152,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let white_id = renderer.add_shape(white, Some(red_id), None).unwrap();
-                renderer.set_shape_color(white_id, Some(Color::rgb(255, 255, 255)));
+                renderer
+                    .set_shape_color(white_id, Some(Color::rgb(255, 255, 255)))
+                    .unwrap();
 
                 let shape_that_doesnt_fit = Shape::rounded_rect(
                     [(0.0, 0.0), (20.0, 20.0)],
@@ -156,14 +168,18 @@ impl<'a> ApplicationHandler for App<'a> {
                 // ids were created above
 
                 // Recreate previous offsets with transforms
-                renderer.set_shape_transform(
-                    green_id,
-                    grafo::TransformInstance::translation(100.0, 100.0),
-                );
-                renderer.set_shape_transform(
-                    blue_id,
-                    grafo::TransformInstance::translation(150.0, 150.0),
-                );
+                renderer
+                    .set_shape_transform(
+                        green_id,
+                        grafo::TransformInstance::translation(100.0, 100.0),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_transform(
+                        blue_id,
+                        grafo::TransformInstance::translation(150.0, 150.0),
+                    )
+                    .unwrap();
                 // yellow, white, shape_that_doesnt_fit used (0,0) so identity is fine
                 let _ = (yellow_id, white_id, doesnt_fit_id);
 
@@ -199,25 +215,43 @@ impl<'a> ApplicationHandler for App<'a> {
                     .unwrap();
                 let img_rect3_id = renderer.add_shape(img_rect3, None, None).unwrap();
 
-                renderer.set_shape_texture(img_rect1_id, Some(texture_id));
-                renderer.set_shape_texture(img_rect2_id, Some(texture_id));
-                renderer.set_shape_texture(img_rect3_id, Some(texture_id));
-                renderer.set_shape_color(img_rect1_id, Some(Color::rgb(255, 255, 255)));
-                renderer.set_shape_color(img_rect2_id, Some(Color::rgb(255, 255, 255)));
-                renderer.set_shape_color(img_rect3_id, Some(Color::rgb(255, 255, 255)));
+                renderer
+                    .set_shape_texture(img_rect1_id, Some(texture_id))
+                    .unwrap();
+                renderer
+                    .set_shape_texture(img_rect2_id, Some(texture_id))
+                    .unwrap();
+                renderer
+                    .set_shape_texture(img_rect3_id, Some(texture_id))
+                    .unwrap();
+                renderer
+                    .set_shape_color(img_rect1_id, Some(Color::rgb(255, 255, 255)))
+                    .unwrap();
+                renderer
+                    .set_shape_color(img_rect2_id, Some(Color::rgb(255, 255, 255)))
+                    .unwrap();
+                renderer
+                    .set_shape_color(img_rect3_id, Some(Color::rgb(255, 255, 255)))
+                    .unwrap();
 
-                renderer.set_shape_transform(
-                    img_rect1_id,
-                    grafo::TransformInstance::translation(100.0, 100.0),
-                );
-                renderer.set_shape_transform(
-                    img_rect2_id,
-                    grafo::TransformInstance::translation(200.0, 200.0),
-                );
-                renderer.set_shape_transform(
-                    img_rect3_id,
-                    grafo::TransformInstance::translation(400.0, 400.0),
-                );
+                renderer
+                    .set_shape_transform(
+                        img_rect1_id,
+                        grafo::TransformInstance::translation(100.0, 100.0),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_transform(
+                        img_rect2_id,
+                        grafo::TransformInstance::translation(200.0, 200.0),
+                    )
+                    .unwrap();
+                renderer
+                    .set_shape_transform(
+                        img_rect3_id,
+                        grafo::TransformInstance::translation(400.0, 400.0),
+                    )
+                    .unwrap();
 
                 let timer = Instant::now();
                 match renderer.render() {

--- a/examples/winit_softbuffer.rs
+++ b/examples/winit_softbuffer.rs
@@ -129,7 +129,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let bg_id = renderer_guard.add_shape(background, None, None).unwrap();
-                renderer_guard.set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)));
+                renderer_guard
+                    .set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)))
+                    .unwrap();
 
                 let red_id = renderer_guard
                     .add_shape(
@@ -141,8 +143,12 @@ impl<'a> ApplicationHandler for App<'a> {
                         None,
                     )
                     .unwrap();
-                renderer_guard.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
-                renderer_guard.set_shape_transform(red_id, grafo::TransformInstance::identity());
+                renderer_guard
+                    .set_shape_color(red_id, Some(Color::rgb(255, 0, 0)))
+                    .unwrap();
+                renderer_guard
+                    .set_shape_transform(red_id, grafo::TransformInstance::identity())
+                    .unwrap();
 
                 let blue_id = renderer_guard
                     .add_shape(
@@ -154,11 +160,12 @@ impl<'a> ApplicationHandler for App<'a> {
                         None,
                     )
                     .unwrap();
-                renderer_guard.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
-                renderer_guard.set_shape_transform(
-                    blue_id,
-                    grafo::TransformInstance::translation(220.0, 0.0),
-                );
+                renderer_guard
+                    .set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)))
+                    .unwrap();
+                renderer_guard
+                    .set_shape_transform(blue_id, grafo::TransformInstance::translation(220.0, 0.0))
+                    .unwrap();
 
                 // Render to GPU offscreen texture and get ARGB32 pixels
                 let render_start = std::time::Instant::now();

--- a/examples/winit_softbuffer_cpu_swizzle.rs
+++ b/examples/winit_softbuffer_cpu_swizzle.rs
@@ -120,7 +120,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(1.0, Color::rgb(0, 0, 0)),
                 );
                 let bg_id = renderer_guard.add_shape(background, None, None).unwrap();
-                renderer_guard.set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)));
+                renderer_guard
+                    .set_shape_color(bg_id, Some(Color::rgb(255, 255, 200)))
+                    .unwrap();
 
                 let red_id = renderer_guard
                     .add_shape(
@@ -132,8 +134,12 @@ impl<'a> ApplicationHandler for App<'a> {
                         None,
                     )
                     .unwrap();
-                renderer_guard.set_shape_color(red_id, Some(Color::rgb(255, 0, 0)));
-                renderer_guard.set_shape_transform(red_id, grafo::TransformInstance::identity());
+                renderer_guard
+                    .set_shape_color(red_id, Some(Color::rgb(255, 0, 0)))
+                    .unwrap();
+                renderer_guard
+                    .set_shape_transform(red_id, grafo::TransformInstance::identity())
+                    .unwrap();
 
                 let blue_id = renderer_guard
                     .add_shape(
@@ -145,11 +151,12 @@ impl<'a> ApplicationHandler for App<'a> {
                         None,
                     )
                     .unwrap();
-                renderer_guard.set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)));
-                renderer_guard.set_shape_transform(
-                    blue_id,
-                    grafo::TransformInstance::translation(220.0, 0.0),
-                );
+                renderer_guard
+                    .set_shape_color(blue_id, Some(Color::rgb(0, 0, 255)))
+                    .unwrap();
+                renderer_guard
+                    .set_shape_transform(blue_id, grafo::TransformInstance::translation(220.0, 0.0))
+                    .unwrap();
 
                 // Render to BGRA byte buffer
                 let needed_bytes = (window_size.width as usize) * (window_size.height as usize) * 4;

--- a/examples/winit_transparency.rs
+++ b/examples/winit_transparency.rs
@@ -73,7 +73,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(3.0, Color::BLACK),
                 );
                 let id = renderer.add_shape(rect, None, None).unwrap();
-                renderer.set_shape_color(id, Some(Color::rgb(255, 100, 50)));
+                renderer
+                    .set_shape_color(id, Some(Color::rgb(255, 100, 50)))
+                    .unwrap();
 
                 // Create a rounded rectangle to test different shapes
                 let rounded_rect = Shape::rounded_rect(
@@ -82,7 +84,9 @@ impl<'a> ApplicationHandler for App<'a> {
                     Stroke::new(2.0, Color::rgb(0, 100, 200)),
                 );
                 let rid = renderer.add_shape(rounded_rect, None, None).unwrap();
-                renderer.set_shape_color(rid, Some(Color::rgb(100, 200, 255)));
+                renderer
+                    .set_shape_color(rid, Some(Color::rgb(100, 200, 255)))
+                    .unwrap();
 
                 // Render the frame
                 match renderer.render() {

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -44,7 +44,9 @@ pub fn build_main_scene(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let canvas_root_id = renderer.add_shape(canvas_root, None, None).unwrap();
-    renderer.set_shape_color(canvas_root_id, Some(Color::WHITE));
+    renderer
+        .set_shape_color(canvas_root_id, Some(Color::WHITE))
+        .unwrap();
 
     load_shared_resources(renderer);
 
@@ -146,7 +148,9 @@ fn tile_01_rect_solid(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(220, 50, 50)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(220, 50, 50)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 40, 220, 50, 50, "t01_interior"),
@@ -169,7 +173,9 @@ fn tile_02_rounded_rect_solid(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(50, 180, 50)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(50, 180, 50)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 40, 50, 180, 50, "t02_interior"),
@@ -194,7 +200,9 @@ fn tile_03_path_triangle(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         .close()
         .build();
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(50, 50, 220)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(50, 50, 220)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 50, 50, 50, 220, "t03_interior"),
@@ -226,7 +234,9 @@ fn tile_04_path_bezier(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         .close()
         .build();
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(220, 200, 50)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(220, 200, 50)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 40, 220, 200, 50, "t04_interior"),
@@ -250,14 +260,18 @@ fn tile_05_rect_parent_child_inside(renderer: &mut Renderer) -> Vec<PixelExpecta
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)))
+        .unwrap();
 
     let child = Shape::rect(
         [(ox + 20.0, oy + 20.0), (ox + 60.0, oy + 60.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(220, 100, 50)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(220, 100, 50)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -286,7 +300,9 @@ fn tile_06_rect_parent_child_overflow(renderer: &mut Renderer) -> Vec<PixelExpec
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(150, 200, 150)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(150, 200, 150)))
+        .unwrap();
 
     // Child extends past parent's right edge
     let child = Shape::rect(
@@ -294,7 +310,9 @@ fn tile_06_rect_parent_child_overflow(renderer: &mut Renderer) -> Vec<PixelExpec
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 200)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(50, 50, 200)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -333,7 +351,9 @@ fn tile_07_rect_parent_multi_children(renderer: &mut Renderer) -> Vec<PixelExpec
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)))
+        .unwrap();
 
     let child_colors = [
         Color::rgb(220, 50, 50),
@@ -348,7 +368,9 @@ fn tile_07_rect_parent_multi_children(renderer: &mut Renderer) -> Vec<PixelExpec
             Stroke::default(),
         );
         let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-        renderer.set_shape_color(child_id, Some(child_colors[idx]));
+        renderer
+            .set_shape_color(child_id, Some(child_colors[idx]))
+            .unwrap();
     }
 
     vec![
@@ -379,21 +401,27 @@ fn tile_08_rect_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id0 = renderer.add_shape(level0, None, None).unwrap();
-    renderer.set_shape_color(id0, Some(Color::rgb(200, 180, 180)));
+    renderer
+        .set_shape_color(id0, Some(Color::rgb(200, 180, 180)))
+        .unwrap();
 
     let level1 = Shape::rect(
         [(ox + 15.0, oy + 15.0), (ox + 65.0, oy + 65.0)],
         Stroke::default(),
     );
     let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
-    renderer.set_shape_color(id1, Some(Color::rgb(180, 200, 180)));
+    renderer
+        .set_shape_color(id1, Some(Color::rgb(180, 200, 180)))
+        .unwrap();
 
     let level2 = Shape::rect(
         [(ox + 25.0, oy + 25.0), (ox + 55.0, oy + 55.0)],
         Stroke::default(),
     );
     let id2 = renderer.add_shape(level2, Some(id1), None).unwrap();
-    renderer.set_shape_color(id2, Some(Color::rgb(100, 100, 220)));
+    renderer
+        .set_shape_color(id2, Some(Color::rgb(100, 100, 220)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -416,7 +444,9 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(200, 200, 200)))
+        .unwrap();
 
     // First child (drawn first)
     let child1 = Shape::rect(
@@ -424,7 +454,9 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let c1 = renderer.add_shape(child1, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(c1, Some(Color::rgb(220, 50, 50)));
+    renderer
+        .set_shape_color(c1, Some(Color::rgb(220, 50, 50)))
+        .unwrap();
 
     // Second child overlaps first (drawn on top)
     let child2 = Shape::rect(
@@ -432,7 +464,9 @@ fn tile_09_rect_siblings_overlap(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let c2 = renderer.add_shape(child2, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(c2, Some(Color::rgb(50, 50, 220)));
+    renderer
+        .set_shape_color(c2, Some(Color::rgb(50, 50, 220)))
+        .unwrap();
 
     vec![
         // Overlap region — second child on top
@@ -468,7 +502,9 @@ fn tile_10_rounded_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 230)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(200, 200, 230)))
+        .unwrap();
 
     // Child is smaller than parent, leaving a visible parent ring
     let child = Shape::rect(
@@ -476,7 +512,9 @@ fn tile_10_rounded_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(220, 100, 50)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(220, 100, 50)))
+        .unwrap();
 
     vec![
         // Child interior
@@ -512,7 +550,9 @@ fn tile_11_path_parent_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         .close()
         .build();
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)))
+        .unwrap();
 
     // Child rect offset to the right so left part of triangle shows parent color
     let child = Shape::rect(
@@ -520,7 +560,9 @@ fn tile_11_path_parent_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(220, 150, 50)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(220, 150, 50)))
+        .unwrap();
 
     vec![
         // Right side of triangle — child (orange) is visible and clipped to triangle
@@ -563,7 +605,9 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         Stroke::default(),
     );
     let id0 = renderer.add_shape(level0, None, None).unwrap();
-    renderer.set_shape_color(id0, Some(Color::rgb(200, 180, 200))); // lavender
+    renderer
+        .set_shape_color(id0, Some(Color::rgb(200, 180, 200)))
+        .unwrap(); // lavender
 
     // L1: shifted SE — overflows L0 right and bottom.
     // Visible (L0∩L1) ≈ (20,20)→(60,60).
@@ -573,7 +617,9 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         Stroke::default(),
     );
     let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
-    renderer.set_shape_color(id1, Some(Color::rgb(100, 200, 100))); // green
+    renderer
+        .set_shape_color(id1, Some(Color::rgb(100, 200, 100)))
+        .unwrap(); // green
 
     // L2: shifted SW/down — overflows L1 to the left and L0 below.
     // Visible (L0∩L1∩L2) ≈ (20,35)→(50,60).
@@ -583,7 +629,9 @@ fn tile_12_stencil_nested_3_levels(renderer: &mut Renderer) -> Vec<PixelExpectat
         Stroke::default(),
     );
     let id2 = renderer.add_shape(level2, Some(id1), None).unwrap();
-    renderer.set_shape_color(id2, Some(Color::rgb(100, 100, 220))); // blue
+    renderer
+        .set_shape_color(id2, Some(Color::rgb(100, 100, 220)))
+        .unwrap(); // blue
 
     vec![
         // Inside all three → L2 blue
@@ -645,17 +693,25 @@ fn tile_13_rotated_rect_clip(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     // Parent rect defined centered at origin, then rotated+translated
     let parent = Shape::rect([(-20.0, -20.0), (20.0, 20.0)], Stroke::default());
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(200, 200, 180)));
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(200, 200, 180)))
+        .unwrap();
     let rotation = TransformInstance::rotation_z_deg(45.0);
     let translation = TransformInstance::translation(ox + 40.0, oy + 40.0);
     // a.multiply(&b) applies a first, then b: first rotate, then translate
-    renderer.set_shape_transform(parent_id, rotation.multiply(&translation));
+    renderer
+        .set_shape_transform(parent_id, rotation.multiply(&translation))
+        .unwrap();
 
     // Child is smaller than parent — parent ring visible around child
     let child = Shape::rect([(-12.0, -12.0), (12.0, 12.0)], Stroke::default());
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(220, 80, 80)));
-    renderer.set_shape_transform(child_id, rotation.multiply(&translation));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(220, 80, 80)))
+        .unwrap();
+    renderer
+        .set_shape_transform(child_id, rotation.multiply(&translation))
+        .unwrap();
 
     vec![
         // Center of the rotated diamond — child visible
@@ -700,7 +756,9 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id0 = renderer.add_shape(level0, None, None).unwrap();
-    renderer.set_shape_color(id0, Some(Color::rgb(200, 200, 200))); // gray
+    renderer
+        .set_shape_color(id0, Some(Color::rgb(200, 200, 200)))
+        .unwrap(); // gray
 
     // L1: rounded-rect shifted SE — overflows L0 right and bottom → stencil clip.
     // Visible (L0∩L1) ≈ (20,20)→(60,60).
@@ -710,7 +768,9 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
-    renderer.set_shape_color(id1, Some(Color::rgb(180, 220, 180))); // green
+    renderer
+        .set_shape_color(id1, Some(Color::rgb(180, 220, 180)))
+        .unwrap(); // green
 
     // Leaf: rect shifted SW/down — overflows L1 to the left and L0 below.
     // Visible (L0∩L1∩leaf) ≈ (20,35)→(50,60).
@@ -719,7 +779,9 @@ fn tile_14_scissor_then_stencil(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let leaf_id = renderer.add_shape(leaf, Some(id1), None).unwrap();
-    renderer.set_shape_color(leaf_id, Some(Color::rgb(50, 50, 200))); // blue
+    renderer
+        .set_shape_color(leaf_id, Some(Color::rgb(50, 50, 200)))
+        .unwrap(); // blue
 
     vec![
         // Inside all three → leaf blue
@@ -786,7 +848,9 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id0 = renderer.add_shape(level0, None, None).unwrap();
-    renderer.set_shape_color(id0, Some(Color::rgb(220, 200, 200))); // pink
+    renderer
+        .set_shape_color(id0, Some(Color::rgb(220, 200, 200)))
+        .unwrap(); // pink
 
     // L1: rect shifted SE — overflows L0 right and bottom → scissor clip.
     // Visible (L0∩L1) ≈ (20,20)→(60,60).
@@ -795,7 +859,9 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id1 = renderer.add_shape(level1, Some(id0), None).unwrap();
-    renderer.set_shape_color(id1, Some(Color::rgb(200, 220, 200))); // green
+    renderer
+        .set_shape_color(id1, Some(Color::rgb(200, 220, 200)))
+        .unwrap(); // green
 
     // Leaf: rect shifted SW/down — overflows L1 to the left and L0 below.
     // Visible (L0∩L1∩leaf) ≈ (20,35)→(50,60).
@@ -804,7 +870,9 @@ fn tile_15_stencil_then_scissor(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let leaf_id = renderer.add_shape(leaf, Some(id1), None).unwrap();
-    renderer.set_shape_color(leaf_id, Some(Color::rgb(50, 200, 50))); // bright green
+    renderer
+        .set_shape_color(leaf_id, Some(Color::rgb(50, 200, 50)))
+        .unwrap(); // bright green
 
     vec![
         // Inside all three → leaf green
@@ -870,7 +938,9 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id0 = renderer.add_shape(l0, None, None).unwrap();
-    renderer.set_shape_color(id0, Some(Color::rgb(220, 220, 220))); // light gray
+    renderer
+        .set_shape_color(id0, Some(Color::rgb(220, 220, 220)))
+        .unwrap(); // light gray
 
     // L1: rect, wide top portion — overflows L0 to right → scissor.
     // Visible (L0∩L1) = (20,5)→(55,55).
@@ -879,7 +949,9 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id1 = renderer.add_shape(l1, Some(id0), None).unwrap();
-    renderer.set_shape_color(id1, Some(Color::rgb(200, 200, 220))); // blue-gray
+    renderer
+        .set_shape_color(id1, Some(Color::rgb(200, 200, 220)))
+        .unwrap(); // blue-gray
 
     // L2: rounded-rect, tall — overflows L1 below → stencil.
     // Visible (L0∩L1∩L2) ≈ (20,20)→(50,55).
@@ -889,7 +961,9 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id2 = renderer.add_shape(l2, Some(id1), None).unwrap();
-    renderer.set_shape_color(id2, Some(Color::rgb(180, 220, 180))); // green
+    renderer
+        .set_shape_color(id2, Some(Color::rgb(180, 220, 180)))
+        .unwrap(); // green
 
     // L3: rect, wide — overflows L2 right and above → scissor.
     // Visible (L0∩L1∩L2∩L3) ≈ (25,20)→(50,50).
@@ -898,7 +972,9 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id3 = renderer.add_shape(l3, Some(id2), None).unwrap();
-    renderer.set_shape_color(id3, Some(Color::rgb(200, 180, 220))); // purple
+    renderer
+        .set_shape_color(id3, Some(Color::rgb(200, 180, 220)))
+        .unwrap(); // purple
 
     // L4: leaf rect — overflows L3 left and below.
     // Visible (all 5) ≈ (25,30)→(45,50).
@@ -907,7 +983,9 @@ fn tile_16_deep_mixed_5_levels(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id4 = renderer.add_shape(l4, Some(id3), None).unwrap();
-    renderer.set_shape_color(id4, Some(Color::rgb(50, 50, 200))); // blue
+    renderer
+        .set_shape_color(id4, Some(Color::rgb(50, 50, 200)))
+        .unwrap(); // blue
 
     vec![
         // Center of 5-way intersection → L4 blue
@@ -972,8 +1050,12 @@ fn tile_17_translated_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     // Rect defined at origin, translated to bottom-right of tile
     let shape = Shape::rect([(0.0, 0.0), (40.0, 25.0)], Stroke::default());
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(220, 150, 50)));
-    renderer.set_shape_transform(id, TransformInstance::translation(ox + 30.0, oy + 45.0));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(220, 150, 50)))
+        .unwrap();
+    renderer
+        .set_shape_transform(id, TransformInstance::translation(ox + 30.0, oy + 45.0))
+        .unwrap();
 
     vec![
         // Inside the translated rect (bottom-right area)
@@ -1015,12 +1097,16 @@ fn tile_18_scaled_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(150, 50, 200)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(150, 50, 200)))
+        .unwrap();
     // Scale 0.5× horizontal, 1.0× vertical around tile center
     let to_origin = TransformInstance::translation(-(ox + 40.0), -(oy + 40.0));
     let scale = TransformInstance::scale(0.5, 1.0);
     let back = TransformInstance::translation(ox + 40.0, oy + 40.0);
-    renderer.set_shape_transform(id, to_origin.multiply(&scale.multiply(&back)));
+    renderer
+        .set_shape_transform(id, to_origin.multiply(&scale.multiply(&back)))
+        .unwrap();
 
     vec![
         // Center should still have color
@@ -1059,11 +1145,15 @@ fn tile_19_rotated_rect_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(19);
     let shape = Shape::rect([(-15.0, -15.0), (15.0, 15.0)], Stroke::default());
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(220, 100, 100)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(220, 100, 100)))
+        .unwrap();
     let rotation = TransformInstance::rotation_z_deg(45.0);
     let translation = TransformInstance::translation(ox + 40.0, oy + 40.0);
     // a.multiply(&b) applies a first, then b: first rotate, then translate
-    renderer.set_shape_transform(id, rotation.multiply(&translation));
+    renderer
+        .set_shape_transform(id, rotation.multiply(&translation))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 40, 220, 100, 100, "t19_center"),
@@ -1083,20 +1173,28 @@ fn tile_20_transform_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectati
     // Parent translated
     let parent = Shape::rect([(0.0, 0.0), (50.0, 50.0)], Stroke::default());
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)));
-    renderer.set_shape_transform(
-        parent_id,
-        TransformInstance::translation(ox + 15.0, oy + 15.0),
-    );
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgb(180, 180, 220)))
+        .unwrap();
+    renderer
+        .set_shape_transform(
+            parent_id,
+            TransformInstance::translation(ox + 15.0, oy + 15.0),
+        )
+        .unwrap();
 
     // Child at local (10,10)-(40,40) — ends up at tile (25,25)-(55,55)
     let child = Shape::rect([(10.0, 10.0), (40.0, 40.0)], Stroke::default());
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(50, 200, 50)));
-    renderer.set_shape_transform(
-        child_id,
-        TransformInstance::translation(ox + 15.0, oy + 15.0),
-    );
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(50, 200, 50)))
+        .unwrap();
+    renderer
+        .set_shape_transform(
+            child_id,
+            TransformInstance::translation(ox + 15.0, oy + 15.0),
+        )
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(ox as u32 + 40, oy as u32 + 40, 50, 200, 50, "t20_child"),
@@ -1114,7 +1212,9 @@ fn tile_21_alpha_overlap(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(50, 50, 220)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(50, 50, 220)))
+        .unwrap();
 
     // Semi-transparent red on top
     let fg = Shape::rect(
@@ -1122,7 +1222,9 @@ fn tile_21_alpha_overlap(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let fg_id = renderer.add_shape(fg, None, None).unwrap();
-    renderer.set_shape_color(fg_id, Some(Color::rgba(220, 50, 50, 128)));
+    renderer
+        .set_shape_color(fg_id, Some(Color::rgba(220, 50, 50, 128)))
+        .unwrap();
 
     vec![
         // Blue region only
@@ -1163,7 +1265,9 @@ fn tile_22_no_color_default(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(100, 100, 200)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(100, 100, 200)))
+        .unwrap();
 
     let shape = Shape::rect(
         [(ox + 20.0, oy + 20.0), (ox + 60.0, oy + 60.0)],
@@ -1201,7 +1305,9 @@ fn tile_23_fully_transparent(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::TRANSPARENT));
+    renderer
+        .set_shape_color(id, Some(Color::TRANSPARENT))
+        .unwrap();
 
     // Transparent shape over white canvas root → shows white
     vec![PixelExpectation::opaque(
@@ -1223,9 +1329,11 @@ fn tile_24_textured_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID));
+    renderer
+        .set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID))
+        .unwrap();
     // White color so texture shows through unmodified
-    renderer.set_shape_color(id, Some(Color::WHITE));
+    renderer.set_shape_color(id, Some(Color::WHITE)).unwrap();
 
     vec![
         // Textured interior — should not be fully white or fully transparent
@@ -1259,8 +1367,12 @@ fn tile_25_textured_with_color(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID));
-    renderer.set_shape_color(id, Some(Color::rgb(255, 100, 100)));
+    renderer
+        .set_shape_texture(id, Some(CHECKERBOARD_TEXTURE_ID))
+        .unwrap();
+    renderer
+        .set_shape_color(id, Some(Color::rgb(255, 100, 100)))
+        .unwrap();
 
     vec![
         PixelExpectation::new(
@@ -1292,15 +1404,21 @@ fn tile_26_textured_parent_child(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_texture(parent_id, Some(CHECKERBOARD_TEXTURE_ID));
-    renderer.set_shape_color(parent_id, Some(Color::WHITE));
+    renderer
+        .set_shape_texture(parent_id, Some(CHECKERBOARD_TEXTURE_ID))
+        .unwrap();
+    renderer
+        .set_shape_color(parent_id, Some(Color::WHITE))
+        .unwrap();
 
     let child = Shape::rect(
         [(ox + 25.0, oy + 25.0), (ox + 55.0, oy + 55.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(220, 50, 50)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(220, 50, 50)))
+        .unwrap();
 
     vec![
         // Child interior on top of textured parent
@@ -1337,7 +1455,9 @@ fn tile_27_group_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg_stripe, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50))); // green stripe
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(50, 180, 50)))
+        .unwrap(); // green stripe
 
     // Blurred shape (slightly transparent so stripe shows through)
     let shape = Shape::rect(
@@ -1345,7 +1465,9 @@ fn tile_27_group_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgba(220, 50, 50, 200))); // semi-transparent red
+    renderer
+        .set_shape_color(id, Some(Color::rgba(220, 50, 50, 200)))
+        .unwrap(); // semi-transparent red
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -1391,7 +1513,9 @@ fn tile_28_group_blur_with_children(renderer: &mut Renderer) -> Vec<PixelExpecta
         Stroke::default(),
     );
     let bg_stripe_id = renderer.add_shape(bg_stripe, None, None).unwrap();
-    renderer.set_shape_color(bg_stripe_id, Some(Color::rgb(220, 180, 50))); // yellow stripe
+    renderer
+        .set_shape_color(bg_stripe_id, Some(Color::rgb(220, 180, 50)))
+        .unwrap(); // yellow stripe
 
     // Blurred parent (group effect applies to parent+child as a unit)
     let parent = Shape::rect(
@@ -1399,14 +1523,18 @@ fn tile_28_group_blur_with_children(renderer: &mut Renderer) -> Vec<PixelExpecta
         Stroke::default(),
     );
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_color(parent_id, Some(Color::rgba(200, 200, 200, 200))); // semi-transparent gray
+    renderer
+        .set_shape_color(parent_id, Some(Color::rgba(200, 200, 200, 200)))
+        .unwrap(); // semi-transparent gray
 
     let child = Shape::rect(
         [(ox + 20.0, oy + 20.0), (ox + 60.0, oy + 60.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 220)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(50, 50, 220)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -1453,7 +1581,9 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)))
+        .unwrap();
 
     // Sharp-edged stripe that partially overlaps the backdrop panel.
     // Outside the panel it should be crisp; under the panel it should get blurred.
@@ -1462,7 +1592,9 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         Stroke::default(),
     );
     let stripe_id = renderer.add_shape(stripe, None, None).unwrap();
-    renderer.set_shape_color(stripe_id, Some(Color::rgb(50, 50, 220))); // blue stripe
+    renderer
+        .set_shape_color(stripe_id, Some(Color::rgb(50, 50, 220)))
+        .unwrap(); // blue stripe
 
     // Backdrop blur panel on top (leaf, no children)
     let panel = Shape::rect(
@@ -1470,7 +1602,9 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         Stroke::default(),
     );
     let panel_id = renderer.add_shape(panel, None, None).unwrap();
-    renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
+    renderer
+        .set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -1516,7 +1650,9 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(50, 180, 50)))
+        .unwrap();
 
     // Sharp-edged stripe partially behind the backdrop panel
     let stripe = Shape::rect(
@@ -1524,7 +1660,9 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let stripe_id = renderer.add_shape(stripe, None, None).unwrap();
-    renderer.set_shape_color(stripe_id, Some(Color::rgb(220, 50, 50))); // red stripe
+    renderer
+        .set_shape_color(stripe_id, Some(Color::rgb(220, 50, 50)))
+        .unwrap(); // red stripe
 
     // Backdrop panel with a child
     let panel = Shape::rect(
@@ -1532,14 +1670,18 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         Stroke::default(),
     );
     let panel_id = renderer.add_shape(panel, None, None).unwrap();
-    renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
+    renderer
+        .set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)))
+        .unwrap();
 
     let child = Shape::rect(
         [(ox + 25.0, oy + 50.0), (ox + 55.0, oy + 65.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(panel_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(50, 50, 220)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(50, 50, 220)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -1583,7 +1725,9 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(220, 180, 50)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(220, 180, 50)))
+        .unwrap();
 
     // Sharp-edged blue stripe as child of bg — partially behind the backdrop panel
     let stripe = Shape::rect(
@@ -1591,7 +1735,9 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let stripe_id = renderer.add_shape(stripe, Some(bg_id), None).unwrap();
-    renderer.set_shape_color(stripe_id, Some(Color::rgb(50, 50, 200))); // blue stripe
+    renderer
+        .set_shape_color(stripe_id, Some(Color::rgb(50, 50, 200)))
+        .unwrap(); // blue stripe
 
     // Scissor-clipping parent (child of bg, sibling of stripe — drawn after stripe)
     let clip_parent = Shape::rect(
@@ -1599,7 +1745,9 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let clip_id = renderer.add_shape(clip_parent, Some(bg_id), None).unwrap();
-    renderer.set_shape_color(clip_id, Some(Color::rgba(0, 0, 0, 0))); // transparent — just clips
+    renderer
+        .set_shape_color(clip_id, Some(Color::rgba(0, 0, 0, 0)))
+        .unwrap(); // transparent — just clips
 
     // Backdrop panel inside scissor-clipped parent
     let panel = Shape::rect(
@@ -1607,7 +1755,9 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let panel_id = renderer.add_shape(panel, Some(clip_id), None).unwrap();
-    renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
+    renderer
+        .set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -1661,7 +1811,9 @@ fn tile_32_tiny_1px_shape(renderer: &mut Renderer) -> Vec<PixelExpectation> {
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(255, 0, 255)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(255, 0, 255)))
+        .unwrap();
 
     // Small shape — check that the general area has some color
     // Anti-aliasing fringe might spread the pixel
@@ -1686,7 +1838,9 @@ fn tile_33_shape_at_canvas_edge(renderer: &mut Renderer) -> Vec<PixelExpectation
         Stroke::default(),
     );
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(180, 50, 180)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(180, 50, 180)))
+        .unwrap();
 
     vec![
         // Interior of the visible portion
@@ -1713,7 +1867,9 @@ fn tile_34_cached_shape(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let id = renderer
         .add_cached_shape_to_the_render_queue(cache_key, None)
         .unwrap();
-    renderer.set_shape_color(id, Some(Color::rgb(50, 180, 220)));
+    renderer
+        .set_shape_color(id, Some(Color::rgb(50, 180, 220)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -1744,14 +1900,18 @@ fn tile_35_trivial_transform_transparent_leaf(renderer: &mut Renderer) -> Vec<Pi
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(40, 90, 200)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(40, 90, 200)))
+        .unwrap();
 
     let leaf = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
     let leaf_id = renderer.add_shape(leaf, None, None).unwrap();
-    renderer.set_shape_transform(
-        leaf_id,
-        TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
-    );
+    renderer
+        .set_shape_transform(
+            leaf_id,
+            TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
+        )
+        .unwrap();
 
     vec![PixelExpectation::opaque(
         ox as u32 + 40,
@@ -1768,17 +1928,21 @@ fn tile_36_trivial_transform_transparent_parent(renderer: &mut Renderer) -> Vec<
 
     let parent = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_transform(
-        parent_id,
-        TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
-    );
+    renderer
+        .set_shape_transform(
+            parent_id,
+            TransformInstance::affine_2d(2.0, 0.0, 0.0, 2.0, ox + 20.0, oy + 20.0),
+        )
+        .unwrap();
 
     let child = Shape::rect(
         [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 40.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(30, 110, 220)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(30, 110, 220)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -1808,15 +1972,21 @@ fn tile_37_textured_transparent_rects(renderer: &mut Renderer) -> Vec<PixelExpec
         Stroke::default(),
     );
     let explicit_alpha_zero_id = renderer.add_shape(explicit_alpha_zero, None, None).unwrap();
-    renderer.set_shape_color(explicit_alpha_zero_id, Some(Color::rgba(255, 0, 0, 0)));
-    renderer.set_shape_texture(explicit_alpha_zero_id, Some(SOLID_GREEN_TEXTURE_ID));
+    renderer
+        .set_shape_color(explicit_alpha_zero_id, Some(Color::rgba(255, 0, 0, 0)))
+        .unwrap();
+    renderer
+        .set_shape_texture(explicit_alpha_zero_id, Some(SOLID_GREEN_TEXTURE_ID))
+        .unwrap();
 
     let none_color = Shape::rect(
         [(ox + 40.0, oy + 10.0), (ox + 60.0, oy + 30.0)],
         Stroke::default(),
     );
     let none_color_id = renderer.add_shape(none_color, None, None).unwrap();
-    renderer.set_shape_texture(none_color_id, Some(SOLID_GREEN_TEXTURE_ID));
+    renderer
+        .set_shape_texture(none_color_id, Some(SOLID_GREEN_TEXTURE_ID))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -1843,17 +2013,21 @@ fn tile_38_sheared_transparent_parent(renderer: &mut Renderer) -> Vec<PixelExpec
 
     let parent = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
     let parent_id = renderer.add_shape(parent, None, None).unwrap();
-    renderer.set_shape_transform(
-        parent_id,
-        TransformInstance::affine_2d(1.0, 0.0, 0.5, 1.0, ox + 20.0, oy + 20.0),
-    );
+    renderer
+        .set_shape_transform(
+            parent_id,
+            TransformInstance::affine_2d(1.0, 0.0, 0.5, 1.0, ox + 20.0, oy + 20.0),
+        )
+        .unwrap();
 
     let child = Shape::rect(
         [(ox + 15.0, oy + 15.0), (ox + 55.0, oy + 45.0)],
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(20, 120, 230)));
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(20, 120, 230)))
+        .unwrap();
 
     vec![
         PixelExpectation::opaque(
@@ -1916,7 +2090,9 @@ fn tile_39_linear_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     let (ox, oy) = tile_origin(39);
     let shape = Shape::rect([(0.0, 0.0), (60.0, 60.0)], Stroke::default());
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_transform(id, TransformInstance::translation(ox + 10.0, oy + 10.0));
+    renderer
+        .set_shape_transform(id, TransformInstance::translation(ox + 10.0, oy + 10.0))
+        .unwrap();
 
     let gradient = Gradient::linear(LinearGradientDesc {
         common: two_stop_common_canvas((220, 30, 30), (30, 30, 220), SpreadMode::Pad),
@@ -1927,7 +2103,9 @@ fn tile_39_linear_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Canvas units are evaluated in screen space, so the transformed shape still
@@ -1971,7 +2149,9 @@ fn tile_40_radial_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Center should be yellowish
@@ -2065,7 +2245,9 @@ fn tile_41_conic_gradient(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Right of center (0°) should be reddish
@@ -2137,7 +2319,9 @@ fn tile_42_repeating_linear_gradient(renderer: &mut Renderer) -> Vec<PixelExpect
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Midpoint of first period (10px in 20px period) should be bluish
@@ -2228,7 +2412,9 @@ fn tile_43_gradient_hard_stops(renderer: &mut Renderer) -> Vec<PixelExpectation>
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Just left of the 50% boundary should still be red.
@@ -2282,7 +2468,9 @@ fn tile_44_gradient_clipped(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(child_id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(child_id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Center should have a gradient mix
@@ -2317,7 +2505,9 @@ fn tile_45_gradient_group_blur(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg_stripe, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(50, 180, 50))); // green stripe
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(50, 180, 50)))
+        .unwrap(); // green stripe
 
     // Gradient-filled shape with group blur
     let shape = Shape::rect(
@@ -2335,7 +2525,9 @@ fn tile_45_gradient_group_blur(renderer: &mut Renderer) -> Vec<PixelExpectation>
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -2382,7 +2574,9 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let bg_id = renderer.add_shape(bg, None, None).unwrap();
-    renderer.set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)));
+    renderer
+        .set_shape_color(bg_id, Some(Color::rgb(220, 50, 50)))
+        .unwrap();
 
     // Gradient stripe that partially overlaps the backdrop panel.
     // Outside the panel it should be crisp; under the panel it should get blurred.
@@ -2401,7 +2595,9 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(stripe_id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(stripe_id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     // Backdrop blur panel on top (leaf, no children)
     let panel = Shape::rect(
@@ -2409,7 +2605,9 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         Stroke::default(),
     );
     let panel_id = renderer.add_shape(panel, None, None).unwrap();
-    renderer.set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)));
+    renderer
+        .set_shape_color(panel_id, Some(Color::rgba(255, 255, 255, 80)))
+        .unwrap();
 
     let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
@@ -2472,7 +2670,9 @@ fn tile_47_gradient_nonleaf_stencil(renderer: &mut Renderer) -> Vec<PixelExpecta
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(parent_id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(parent_id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     // Small opaque child in the center.
     let child = Shape::rect(
@@ -2480,7 +2680,9 @@ fn tile_47_gradient_nonleaf_stencil(renderer: &mut Renderer) -> Vec<PixelExpecta
         Stroke::default(),
     );
     let child_id = renderer.add_shape(child, Some(parent_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(Color::rgb(255, 255, 0))); // yellow
+    renderer
+        .set_shape_color(child_id, Some(Color::rgb(255, 255, 0)))
+        .unwrap(); // yellow
 
     vec![
         // Left side of parent (gradient should be red-ish, not white/background).
@@ -2536,7 +2738,9 @@ fn tile_48_gradient_state_leak(renderer: &mut Renderer) -> Vec<PixelExpectation>
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(grad_id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(grad_id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     // Second: solid cyan rect (right half), drawn immediately after the gradient.
     let solid_shape = Shape::rect(
@@ -2544,7 +2748,9 @@ fn tile_48_gradient_state_leak(renderer: &mut Renderer) -> Vec<PixelExpectation>
         Stroke::default(),
     );
     let solid_id = renderer.add_shape(solid_shape, None, None).unwrap();
-    renderer.set_shape_color(solid_id, Some(Color::rgb(0, 220, 220))); // cyan
+    renderer
+        .set_shape_color(solid_id, Some(Color::rgb(0, 220, 220)))
+        .unwrap(); // cyan
 
     vec![
         // Gradient rect center: should be a gradient mix (yellow-ish).
@@ -2653,7 +2859,9 @@ fn tile_49_conic_quadrant_colors(renderer: &mut Renderer) -> Vec<PixelExpectatio
     })
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::Gradient(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::Gradient(gradient)))
+        .unwrap();
 
     vec![
         // Bottom of center (90°, atan2(+y, 0)) — should be green.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@
 //!         );
 //!         let rect_id = renderer.add_shape(rect, None, None).expect("to add shape to the renderer");
 //!         // Set per-instance fill color (shapes are transparent by default)
-//!         renderer.set_shape_color(rect_id, Some(Color::rgb(0, 128, 255)));
-//!         renderer.set_shape_transform(rect_id, grafo::TransformInstance::identity());
+//!         renderer.set_shape_color(rect_id, Some(Color::rgb(0, 128, 255))).unwrap();
+//!         renderer.set_shape_transform(rect_id, grafo::TransformInstance::identity()).unwrap();
 //!
 //!         self.window = Some(window);
 //!         self.renderer = Some(renderer);

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -2,6 +2,10 @@ use super::types::{ClipRectDrawData, DrawCommandError};
 use super::*;
 use crate::gradient::types::Fill;
 
+fn clip_rect_supports_transform(transform: InstanceTransform) -> bool {
+    super::rect_utils::extract_axis_aligned_rect_transform(Some(transform)).is_some()
+}
+
 impl<'a> Renderer<'a> {
     pub fn add_shape(
         &mut self,
@@ -18,8 +22,9 @@ impl<'a> Renderer<'a> {
     /// Adds an axis-aligned scissor clipping rectangle without preparing geometry.
     ///
     /// This node clips its children like a transparent rect parent when its transform
-    /// preserves axis alignment. Rotated, skewed, or perspective transforms cannot
-    /// fall back to stencil because this node intentionally has no geometry.
+    /// preserves axis alignment. Rotated, skewed, or perspective transforms are
+    /// rejected by the transform setters because this node intentionally has no
+    /// geometry for stencil fallback.
     pub fn add_clipping_rect(
         &mut self,
         rect_bounds: [(f32, f32); 2],
@@ -118,7 +123,11 @@ impl<'a> Renderer<'a> {
         }
     }
 
-    pub fn set_shape_transform_cols(&mut self, node_id: usize, cols: [[f32; 4]; 4]) {
+    pub fn set_shape_transform_cols(
+        &mut self,
+        node_id: usize,
+        cols: [[f32; 4]; 4],
+    ) -> Result<(), DrawCommandError> {
         let transform = InstanceTransform {
             col0: cols[0],
             col1: cols[1],
@@ -126,22 +135,32 @@ impl<'a> Renderer<'a> {
             col3: cols[3],
         };
 
-        let Some(draw_command) = self.draw_tree.get_mut(node_id) else {
-            return;
-        };
-        draw_command.set_transform(transform);
+        self.set_shape_transform(node_id, transform)
     }
 
-    pub fn set_shape_transform(&mut self, node_id: usize, transform: impl Into<InstanceTransform>) {
+    pub fn set_shape_transform(
+        &mut self,
+        node_id: usize,
+        transform: impl Into<InstanceTransform>,
+    ) -> Result<(), DrawCommandError> {
         let transform = transform.into();
-        let Some(draw_command) = self.draw_tree.get_mut(node_id) else {
-            return;
-        };
+        let draw_command = self
+            .draw_tree
+            .get_mut(node_id)
+            .ok_or(DrawCommandError::InvalidShapeId(node_id))?;
+        if draw_command.is_clip_rect() && !clip_rect_supports_transform(transform) {
+            return Err(DrawCommandError::UnsupportedClipRectTransform(node_id));
+        }
         draw_command.set_transform(transform);
+        Ok(())
     }
 
-    pub fn set_shape_texture(&mut self, node_id: usize, texture_id: Option<u64>) {
-        self.set_shape_texture_layer(node_id, 0, texture_id);
+    pub fn set_shape_texture(
+        &mut self,
+        node_id: usize,
+        texture_id: Option<u64>,
+    ) -> Result<(), DrawCommandError> {
+        self.set_shape_texture_layer(node_id, 0, texture_id)
     }
 
     pub fn set_shape_texture_layer(
@@ -149,15 +168,22 @@ impl<'a> Renderer<'a> {
         node_id: usize,
         layer: usize,
         texture_id: Option<u64>,
-    ) {
+    ) -> Result<(), DrawCommandError> {
         if layer > 1 {
-            return;
+            return Err(DrawCommandError::InvalidTextureLayer(layer));
         }
 
-        let Some(draw_command) = self.draw_tree.get_mut(node_id) else {
-            return;
-        };
+        let draw_command = self
+            .draw_tree
+            .get_mut(node_id)
+            .ok_or(DrawCommandError::InvalidShapeId(node_id))?;
+        if draw_command.is_clip_rect() {
+            return Err(DrawCommandError::UnsupportedClipRectOperation(
+                node_id, "textures",
+            ));
+        }
         draw_command.set_texture_id(layer, texture_id);
+        Ok(())
     }
 
     pub fn set_shape_texture_on(
@@ -165,15 +191,25 @@ impl<'a> Renderer<'a> {
         node_id: usize,
         layer: TextureLayer,
         texture_id: Option<u64>,
-    ) {
-        self.set_shape_texture_layer(node_id, layer.into(), texture_id);
+    ) -> Result<(), DrawCommandError> {
+        self.set_shape_texture_layer(node_id, layer.into(), texture_id)
     }
 
-    pub fn set_shape_color(&mut self, node_id: usize, color: Option<Color>) {
+    pub fn set_shape_color(
+        &mut self,
+        node_id: usize,
+        color: Option<Color>,
+    ) -> Result<(), DrawCommandError> {
         let normalized_color = color.map(|value| value.normalize());
-        let Some(draw_command) = self.draw_tree.get_mut(node_id) else {
-            return;
-        };
+        let draw_command = self
+            .draw_tree
+            .get_mut(node_id)
+            .ok_or(DrawCommandError::InvalidShapeId(node_id))?;
+        if draw_command.is_clip_rect() {
+            return Err(DrawCommandError::UnsupportedClipRectOperation(
+                node_id, "color",
+            ));
+        }
         draw_command.set_instance_color_override(normalized_color);
         // set_shape_color is sugar for Fill::Solid / None
         let fill = color.map(Fill::Solid);
@@ -186,12 +222,23 @@ impl<'a> Renderer<'a> {
             &self.gradient_ramp_sampler,
             self.gradient_bind_group_layout_epoch,
         );
+        Ok(())
     }
 
-    pub fn set_shape_fill(&mut self, node_id: usize, fill: Option<Fill>) {
-        let Some(draw_command) = self.draw_tree.get_mut(node_id) else {
-            return;
-        };
+    pub fn set_shape_fill(
+        &mut self,
+        node_id: usize,
+        fill: Option<Fill>,
+    ) -> Result<(), DrawCommandError> {
+        let draw_command = self
+            .draw_tree
+            .get_mut(node_id)
+            .ok_or(DrawCommandError::InvalidShapeId(node_id))?;
+        if draw_command.is_clip_rect() {
+            return Err(DrawCommandError::UnsupportedClipRectOperation(
+                node_id, "fill",
+            ));
+        }
         // Derive color_override from fill for the solid fast path
         let color_override = match &fill {
             Some(Fill::Solid(color)) => Some(color.normalize()),
@@ -207,5 +254,6 @@ impl<'a> Renderer<'a> {
             &self.gradient_ramp_sampler,
             self.gradient_bind_group_layout_epoch,
         );
+        Ok(())
     }
 }

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -228,6 +228,12 @@ impl DrawCommand {
 pub enum DrawCommandError {
     #[error("Shape with id {0} doesn't exist in the draw tree.")]
     InvalidShapeId(usize),
+    #[error("Texture layer {0} is invalid; expected 0 or 1.")]
+    InvalidTextureLayer(usize),
+    #[error("Clip rect node {0} only supports axis-aligned transforms.")]
+    UnsupportedClipRectTransform(usize),
+    #[error("Clip rect node {0} does not support {1}.")]
+    UnsupportedClipRectOperation(usize, &'static str),
 }
 
 #[derive(Debug)]

--- a/tests/visual_regression.rs
+++ b/tests/visual_regression.rs
@@ -93,7 +93,9 @@ fn single_root_no_children() {
 
     let shape = grafo::Shape::rect([(10.0, 10.0), (100.0, 100.0)], grafo::Stroke::default());
     let id = renderer.add_shape(shape, None, None).unwrap();
-    renderer.set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)));
+    renderer
+        .set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)))
+        .unwrap();
 
     let mut pixel_buffer: Vec<u8> = Vec::new();
     renderer.render_to_buffer(&mut pixel_buffer);
@@ -118,7 +120,9 @@ fn clipping_rect_clips_child_without_visible_surface() {
         .unwrap();
     let child = grafo::Shape::rect([(0.0, 0.0), (100.0, 100.0)], grafo::Stroke::default());
     let child_id = renderer.add_shape(child, Some(clip_rect_id), None).unwrap();
-    renderer.set_shape_color(child_id, Some(grafo::Color::rgb(200, 50, 50)));
+    renderer
+        .set_shape_color(child_id, Some(grafo::Color::rgb(200, 50, 50)))
+        .unwrap();
 
     let mut pixel_buffer: Vec<u8> = Vec::new();
     renderer.render_to_buffer(&mut pixel_buffer);
@@ -154,6 +158,46 @@ fn standalone_clipping_rect_does_not_panic() {
     );
 }
 
+/// Regression test — unsupported clip-rect transforms are rejected instead of disabling clipping.
+#[test]
+fn clipping_rect_rejects_non_axis_aligned_transform() {
+    let Some(mut renderer) = create_headless_renderer() else {
+        return;
+    };
+
+    let clip_rect_id = renderer
+        .add_clipping_rect([(20.0, 20.0), (80.0, 80.0)], None)
+        .unwrap();
+    assert!(matches!(
+        renderer.set_shape_transform(clip_rect_id, grafo::TransformInstance::rotation_z_deg(45.0)),
+        Err(grafo::DrawCommandError::UnsupportedClipRectTransform(node_id))
+            if node_id == clip_rect_id
+    ));
+
+    let child = grafo::Shape::rect([(0.0, 0.0), (100.0, 100.0)], grafo::Stroke::default());
+    let child_id = renderer.add_shape(child, Some(clip_rect_id), None).unwrap();
+    renderer
+        .set_shape_color(child_id, Some(grafo::Color::rgb(200, 50, 50)))
+        .unwrap();
+
+    let mut pixel_buffer: Vec<u8> = Vec::new();
+    renderer.render_to_buffer(&mut pixel_buffer);
+
+    let expectations = vec![
+        grafo_test_scenes::PixelExpectation::opaque(
+            50,
+            50,
+            200,
+            50,
+            50,
+            "inside_unrotated_clip_rect",
+        ),
+        grafo_test_scenes::PixelExpectation::transparent(10, 50, "outside_unrotated_clip_rect"),
+    ];
+
+    assert_pixels_match(&pixel_buffer, &expectations);
+}
+
 /// Smoke test — gradient fill should produce non-transparent pixels.
 #[test]
 fn gradient_fill_basic() {
@@ -166,7 +210,9 @@ fn gradient_fill_basic() {
     // Root shape
     let root = Shape::rect([(0.0, 0.0), (100.0, 100.0)], Stroke::default());
     let root_id = renderer.add_shape(root, None, None).unwrap();
-    renderer.set_shape_color(root_id, Some(Color::WHITE));
+    renderer
+        .set_shape_color(root_id, Some(Color::WHITE))
+        .unwrap();
 
     // Gradient child
     let child = Shape::rect([(10.0, 10.0), (90.0, 90.0)], Stroke::default());
@@ -193,7 +239,9 @@ fn gradient_fill_basic() {
     )
     .expect("valid gradient");
 
-    renderer.set_shape_fill(child_id, Some(Fill::from(gradient)));
+    renderer
+        .set_shape_fill(child_id, Some(Fill::from(gradient)))
+        .unwrap();
 
     let mut pixel_buffer: Vec<u8> = Vec::new();
     renderer.render_to_buffer(&mut pixel_buffer);
@@ -252,7 +300,9 @@ fn gradient_survives_pipeline_recreation() {
     )
     .expect("valid gradient");
 
-    renderer.set_shape_fill(id, Some(Fill::from(gradient)));
+    renderer
+        .set_shape_fill(id, Some(Fill::from(gradient)))
+        .unwrap();
 
     // First render — populates and caches the gradient bind group.
     let mut buf = Vec::new();
@@ -321,7 +371,9 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
             None,
         )
         .unwrap();
-    renderer.set_shape_color(root, Some(Color::rgba(0, 0, 0, 0)));
+    renderer
+        .set_shape_color(root, Some(Color::rgba(0, 0, 0, 0)))
+        .unwrap();
 
     let radii = BorderRadii::new(8.0);
 
@@ -355,7 +407,9 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
     )
     .expect("valid gradient");
 
-    renderer.set_shape_fill(gradient_parent, Some(Fill::from(gradient)));
+    renderer
+        .set_shape_fill(gradient_parent, Some(Fill::from(gradient)))
+        .unwrap();
 
     // Child of gradient parent (makes it non-leaf → StencilIncrement).
     let gradient_child = renderer
@@ -365,7 +419,9 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
             None,
         )
         .unwrap();
-    renderer.set_shape_color(gradient_child, Some(Color::WHITE));
+    renderer
+        .set_shape_color(gradient_child, Some(Color::WHITE))
+        .unwrap();
 
     // ── Solid non-leaf parent (rounded rect → stencil path) ──────────────
     let solid_parent = renderer
@@ -375,7 +431,9 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
             None,
         )
         .unwrap();
-    renderer.set_shape_color(solid_parent, Some(Color::rgb(0, 200, 0)));
+    renderer
+        .set_shape_color(solid_parent, Some(Color::rgb(0, 200, 0)))
+        .unwrap();
 
     // Child of solid parent (makes it non-leaf → StencilIncrement too).
     let solid_child = renderer
@@ -385,7 +443,9 @@ fn stencil_increment_gradient_does_not_leak_to_solid_parent() {
             None,
         )
         .unwrap();
-    renderer.set_shape_color(solid_child, Some(Color::rgb(0, 200, 0)));
+    renderer
+        .set_shape_color(solid_child, Some(Color::rgb(0, 200, 0)))
+        .unwrap();
 
     // ── Render and verify ─────────────────────────────────────────────────
     let mut buf = Vec::new();
@@ -420,7 +480,9 @@ fn multi_subpath_fill_has_no_internal_seam() {
         grafo::Stroke::default(),
     );
     let canvas_root_id = renderer.add_shape(canvas_root, None, None).unwrap();
-    renderer.set_shape_color(canvas_root_id, Some(grafo::Color::WHITE));
+    renderer
+        .set_shape_color(canvas_root_id, Some(grafo::Color::WHITE))
+        .unwrap();
 
     let shape = grafo::Shape::builder()
         .begin((10.0, 10.0))
@@ -435,13 +497,17 @@ fn multi_subpath_fill_has_no_internal_seam() {
     let id = renderer
         .add_shape(shape, Some(canvas_root_id), None)
         .unwrap();
-    renderer.set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)));
+    renderer
+        .set_shape_color(id, Some(grafo::Color::rgb(200, 50, 50)))
+        .unwrap();
 
     let rect = grafo::Shape::rect([(140.0, 10.0), (230.0, 100.0)], grafo::Stroke::default());
     let rect_id = renderer
         .add_shape(rect, Some(canvas_root_id), None)
         .unwrap();
-    renderer.set_shape_color(rect_id, Some(grafo::Color::rgb(200, 50, 50)));
+    renderer
+        .set_shape_color(rect_id, Some(grafo::Color::rgb(200, 50, 50)))
+        .unwrap();
 
     let mut pixel_buffer: Vec<u8> = Vec::new();
     renderer.render_to_buffer(&mut pixel_buffer);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Renderer configuration methods (`set_shape_color`, `set_shape_transform`, `set_shape_texture`) now return explicit error results instead of silently failing, providing clearer feedback on invalid operations.
  * Added validation to reject unsupported transform types on clipping rectangles.
  * Invalid shape IDs and texture layers now return distinct error variants.

* **Chores**
  * Updated all examples and tests to handle operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->