### PR TITLE
feat: add a texture fill mode that doesn't stretch the texture

### DIFF
--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -2,8 +2,8 @@ use grafo::{
     BorderRadii, Color, ColorInterpolation, ConicGradientDesc, Fill, Gradient, GradientColor,
     GradientCommonDesc, GradientStop, GradientStopOffset, GradientStopPositions, GradientUnits,
     LinearGradientDesc, LinearGradientLine, RadialGradientDesc, RadialGradientShape,
-    RadialGradientSize, Renderer, Shape, ShapeDrawCommandOptions, SpreadMode, Stroke,
-    TransformInstance,
+    RadialGradientSize, Renderer, Shape, ShapeDrawCommandOptions, ShapeTextureFitMode,
+    ShapeTextureOptions, SpreadMode, Stroke, TransformInstance,
 };
 
 use crate::expectations::PixelExpectation;
@@ -21,6 +21,8 @@ pub const CANVAS_HEIGHT: u32 = TILE_SIZE * ROWS;
 const BLUR_EFFECT_ID: u64 = 1;
 const CHECKERBOARD_TEXTURE_ID: u64 = 100;
 const SOLID_GREEN_TEXTURE_ID: u64 = 101;
+const SOLID_GREEN_20X20_TEXTURE_ID: u64 = 102;
+const SOLID_RED_TEXTURE_ID: u64 = 103;
 
 /// Returns the pixel origin (top-left corner) of tile number `n` (1-based).
 fn tile_origin(tile_number: u32) -> (f32, f32) {
@@ -111,6 +113,8 @@ pub fn build_main_scene(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     expectations.extend(tile_50_overflow_visible_delegates_to_ancestor(renderer));
     expectations.extend(tile_51_clip_rect_overflow_visible_container(renderer));
     expectations.extend(tile_52_backdrop_overflow_visible_children(renderer));
+    expectations.extend(tile_53_texture_original_size(renderer));
+    expectations.extend(tile_54_texture_original_size_scaled(renderer));
 
     expectations
 }
@@ -144,6 +148,21 @@ fn load_shared_resources(renderer: &mut Renderer) {
         SOLID_GREEN_TEXTURE_ID,
         (1, 1),
         &[0, 255, 0, 255],
+    );
+    renderer.texture_manager().allocate_texture_with_data(
+        SOLID_RED_TEXTURE_ID,
+        (1, 1),
+        &[255, 0, 0, 255],
+    );
+
+    let solid_green_20x20 = vec![255u8; 20 * 20 * 4]
+        .chunks_exact(4)
+        .flat_map(|_| [0u8, 255u8, 0u8, 255u8])
+        .collect::<Vec<_>>();
+    renderer.texture_manager().allocate_texture_with_data(
+        SOLID_GREEN_20X20_TEXTURE_ID,
+        (20, 20),
+        &solid_green_20x20,
     );
 }
 
@@ -3501,6 +3520,100 @@ fn tile_52_backdrop_overflow_visible_children(renderer: &mut Renderer) -> Vec<Pi
             255,
             255,
             "t52_outer_still_clips_child",
+        ),
+    ]
+}
+
+fn tile_53_texture_original_size(renderer: &mut Renderer) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(53);
+    let shape = Shape::rect(
+        [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            shape,
+            None,
+            None,
+            ShapeDrawCommandOptions::new()
+                .background_texture(ShapeTextureOptions::new(SOLID_RED_TEXTURE_ID))
+                .foreground_texture(
+                    ShapeTextureOptions::new(SOLID_GREEN_20X20_TEXTURE_ID)
+                        .fit_mode(ShapeTextureFitMode::OriginalSize),
+                )
+                .color(Color::WHITE),
+        )
+        .unwrap();
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 20,
+            oy as u32 + 20,
+            0,
+            255,
+            0,
+            "t53_original_size_texture_visible",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 45,
+            oy as u32 + 20,
+            255,
+            0,
+            0,
+            "t53_foreground_original_size_does_not_stretch",
+        ),
+    ]
+}
+
+fn tile_54_texture_original_size_scaled(renderer: &mut Renderer) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(54);
+    let shape = Shape::rect([(0.0, 0.0), (20.0, 20.0)], Stroke::default());
+    renderer
+        .add_shape(
+            shape,
+            None,
+            None,
+            ShapeDrawCommandOptions::new()
+                .background_texture(
+                    ShapeTextureOptions::new(SOLID_GREEN_20X20_TEXTURE_ID)
+                        .fit_mode(ShapeTextureFitMode::OriginalSize),
+                )
+                .color(Color::WHITE)
+                .transform(TransformInstance::affine_2d(
+                    2.0,
+                    0.0,
+                    0.0,
+                    2.0,
+                    ox + 10.0,
+                    oy + 10.0,
+                )),
+        )
+        .unwrap();
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 30,
+            oy as u32 + 30,
+            0,
+            255,
+            0,
+            "t54_scaled_original_size_texture_scales_with_shape_center",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 45,
+            oy as u32 + 20,
+            0,
+            255,
+            0,
+            "t54_scaled_original_size_texture_scales_with_shape_edge",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 55,
+            oy as u32 + 20,
+            255,
+            255,
+            255,
+            "t54_scaled_original_size_texture_clipped_outside_scaled_shape",
         ),
     ]
 }

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -1,6 +1,7 @@
 use super::types::{ClipRectDrawData, DrawCommandError};
 use super::*;
 use crate::ShapeDrawCommandOptions;
+use crate::ShapeTextureFitMode;
 
 fn clip_rect_supports_transform(transform: InstanceTransform) -> bool {
     rect_utils::extract_axis_aligned_rect_transform(Some(transform)).is_some()
@@ -130,6 +131,10 @@ impl<'a> Renderer<'a> {
         if let Some((index_start, index_count)) = index_range {
             cached_shape_data.index_buffer_range = Some((index_start, index_count));
             cached_shape_data.is_empty = false;
+            let texture_uv_scales = self.compute_texture_uv_scales(
+                cached_shape_data.cached_shape.texture_mapping_size,
+                draw_options,
+            );
             let instance_index = preparation::append_instance_data(
                 &mut self.temp_instance_transforms,
                 &mut self.temp_instance_colors,
@@ -139,7 +144,10 @@ impl<'a> Renderer<'a> {
                     None => None,
                     Some(fill) => fill.to_normalized_solid(),
                 },
-                cached_shape_data.texture_ids,
+                preparation::InstanceTextureData {
+                    texture_ids: cached_shape_data.texture_ids,
+                    texture_uv_scales,
+                },
             );
             *cached_shape_data.instance_index_mut() = Some(instance_index);
         } else {
@@ -198,5 +206,50 @@ impl<'a> Renderer<'a> {
         self.trim_scratch_on_resize_or_policy();
         // Clear memory buffers that are used for GPU upload
         self.clear_buffers();
+    }
+
+    fn compute_texture_uv_scales(
+        &self,
+        texture_mapping_size: [f32; 2],
+        draw_options: &ShapeDrawCommandOptions,
+    ) -> [[f32; 2]; 2] {
+        [
+            self.compute_texture_uv_scale_for_layer(
+                draw_options.background_texture.texture_id,
+                draw_options.background_texture.fit_mode,
+                texture_mapping_size,
+            ),
+            self.compute_texture_uv_scale_for_layer(
+                draw_options.foreground_texture.texture_id,
+                draw_options.foreground_texture.fit_mode,
+                texture_mapping_size,
+            ),
+        ]
+    }
+
+    fn compute_texture_uv_scale_for_layer(
+        &self,
+        texture_id: Option<u64>,
+        texture_fit_mode: ShapeTextureFitMode,
+        texture_mapping_size: [f32; 2],
+    ) -> [f32; 2] {
+        if texture_fit_mode != ShapeTextureFitMode::OriginalSize {
+            return [1.0, 1.0];
+        }
+
+        let Some(texture_id) = texture_id else {
+            return [1.0, 1.0];
+        };
+
+        let Some((texture_width, texture_height)) =
+            self.texture_manager.texture_dimensions(texture_id)
+        else {
+            return [1.0, 1.0];
+        };
+
+        [
+            texture_mapping_size[0] * self.scale_factor as f32 / texture_width.max(1) as f32,
+            texture_mapping_size[1] * self.scale_factor as f32 / texture_height.max(1) as f32,
+        ]
     }
 }

--- a/src/renderer/preparation.rs
+++ b/src/renderer/preparation.rs
@@ -1,6 +1,12 @@
 use super::types::decide_buffer_sizing;
 use super::*;
 
+#[derive(Copy, Clone)]
+pub(crate) struct InstanceTextureData {
+    pub(crate) texture_ids: [Option<u64>; 2],
+    pub(crate) texture_uv_scales: [[f32; 2]; 2],
+}
+
 fn upsert_gpu_buffer(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -86,18 +92,20 @@ pub(crate) fn append_instance_data(
     temp_instance_metadata: &mut Vec<InstanceMetadata>,
     transform: Option<InstanceTransform>,
     color_override: Option<[f32; 4]>,
-    texture_ids: [Option<u64>; 2],
+    texture_data: InstanceTextureData,
 ) -> usize {
     let instance_index = temp_instance_transforms.len();
     temp_instance_transforms.push(transform.unwrap_or_else(InstanceTransform::identity));
     temp_instance_colors.push(InstanceColor {
         color: color_override.unwrap_or([0.0, 0.0, 0.0, 0.0]),
     });
-    let texture_flags =
-        (texture_ids[0].is_some() as u32) | ((texture_ids[1].is_some() as u32) << 1);
+    let texture_flags = (texture_data.texture_ids[0].is_some() as u32)
+        | ((texture_data.texture_ids[1].is_some() as u32) << 1);
     temp_instance_metadata.push(InstanceMetadata {
         draw_order: instance_index as f32,
         texture_flags: texture_flags as f32,
+        texture_uv_scale_layer0: texture_data.texture_uv_scales[0],
+        texture_uv_scale_layer1: texture_data.texture_uv_scales[1],
     });
     instance_index
 }

--- a/src/renderer/traversal.rs
+++ b/src/renderer/traversal.rs
@@ -156,6 +156,7 @@ mod tests {
                 vertex_buffers: Arc::new(VertexBuffers::<CustomVertex, u16>::new()),
                 is_rect: false,
                 rect_bounds: None,
+                texture_mapping_size: [1.0, 1.0],
                 geometry_id: None,
             },
             &ShapeDrawCommandOptions::new(),

--- a/src/shaders/shader.wgsl
+++ b/src/shaders/shader.wgsl
@@ -19,26 +19,31 @@ struct VertexInput {
     // Per-instance bitmask: bit 0 = layer 0 active, bit 1 = layer 1 active.
     // 0 = solid fill only (skip all texture samples).
     @location(10) texture_flags: f32,
+    // Per-layer UV scale computed on the CPU from fit mode and texture dimensions.
+    @location(11) texture_uv_scale_layer0: vec2<f32>,
+    @location(12) texture_uv_scale_layer1: vec2<f32>,
 };
 
 struct VertexOutput {
     @invariant @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
 };
 
 struct GradientVertexOutput {
     @invariant @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
     // Model-space position for gradient evaluation (before transform)
-    @location(4) model_pos: vec2<f32>,
+    @location(5) model_pos: vec2<f32>,
     // Screen-space position (pixel coordinates, after transform)
-    @location(5) screen_pos: vec2<f32>,
+    @location(6) screen_pos: vec2<f32>,
 };
 
 // This is a struct that will be used for position normalization
@@ -274,7 +279,8 @@ fn vs_main(input: VertexInput) -> VertexOutput {
     var output: VertexOutput;
     output.position = compute_vertex_position(input);
     output.color = input.color;
-    output.tex_coords = input.tex_coords;
+    output.layer0_tex_coords = input.tex_coords * input.texture_uv_scale_layer0;
+    output.layer1_tex_coords = input.tex_coords * input.texture_uv_scale_layer1;
     output.coverage = input.coverage;
     output.texture_flags = input.texture_flags;
     return output;
@@ -285,7 +291,8 @@ fn vs_main_gradient(input: VertexInput) -> GradientVertexOutput {
     var output: GradientVertexOutput;
     output.position = compute_vertex_position(input);
     output.color = input.color;
-    output.tex_coords = input.tex_coords;
+    output.layer0_tex_coords = input.tex_coords * input.texture_uv_scale_layer0;
+    output.layer1_tex_coords = input.tex_coords * input.texture_uv_scale_layer1;
     output.coverage = input.coverage;
     output.texture_flags = input.texture_flags;
     output.model_pos = input.position;
@@ -319,11 +326,16 @@ fn vs_main_gradient(input: VertexInput) -> GradientVertexOutput {
     return output;
 }
 
+fn texture_coords_are_in_bounds(tex_coords: vec2<f32>) -> bool {
+    return all(tex_coords >= vec2<f32>(0.0, 0.0)) && all(tex_coords <= vec2<f32>(1.0, 1.0));
+}
+
 // Computes the final premultiplied color for a fragment given fill color, texture
 // coordinates, and AA coverage.
 fn compute_fragment_color(
     color: vec4<f32>,
-    tex_coords: vec2<f32>,
+    layer0_tex_coords: vec2<f32>,
+    layer1_tex_coords: vec2<f32>,
     coverage: f32,
     texture_flags: f32,
 ) -> vec4<f32> {
@@ -347,14 +359,14 @@ fn compute_fragment_color(
     // Compose: base = texture layer 0 over shape fill, then layer 1 over result.
     var base_pma = fill_pma;
     if ((flags & 1u) != 0u) {
-        let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, tex_coords, 0.0);
-        base_pma = layer0_pma + fill_pma * (1.0 - layer0_pma.a);
+            let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, layer0_tex_coords, 0.0);
+            base_pma = layer0_pma + fill_pma * (1.0 - layer0_pma.a);
     }
 
     var final_pma = base_pma;
     if ((flags & 2u) != 0u) {
-        let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, tex_coords, 0.0);
-        final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
+            let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, layer1_tex_coords, 0.0);
+            final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
     }
 
     // Apply AA coverage: scale premultiplied color by coverage factor.
@@ -364,7 +376,8 @@ fn compute_fragment_color(
 }
 
 fn compute_gradient_fragment_color(
-    tex_coords: vec2<f32>,
+    layer0_tex_coords: vec2<f32>,
+    layer1_tex_coords: vec2<f32>,
     coverage: f32,
     texture_flags: f32,
     model_pos: vec2<f32>,
@@ -379,14 +392,14 @@ fn compute_gradient_fragment_color(
 
     var base_pma = fill_pma;
     if ((flags & 1u) != 0u) {
-        let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, tex_coords, 0.0);
-        base_pma = layer0_pma + fill_pma * (1.0 - layer0_pma.a);
+            let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, layer0_tex_coords, 0.0);
+            base_pma = layer0_pma + fill_pma * (1.0 - layer0_pma.a);
     }
 
     var final_pma = base_pma;
     if ((flags & 2u) != 0u) {
-        let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, tex_coords, 0.0);
-        final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
+            let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, layer1_tex_coords, 0.0);
+            final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
     }
 
     return final_pma * coverage;
@@ -395,23 +408,38 @@ fn compute_gradient_fragment_color(
 @fragment
 fn fs_main(
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
 ) -> @location(0) vec4<f32> {
-    return compute_fragment_color(color, tex_coords, coverage, texture_flags);
+    return compute_fragment_color(
+        color,
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+    );
 }
 
 @fragment
 fn fs_main_gradient(
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
-    @location(4) model_pos: vec2<f32>,
-    @location(5) screen_pos: vec2<f32>,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
+    @location(5) model_pos: vec2<f32>,
+    @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return compute_gradient_fragment_color(tex_coords, coverage, texture_flags, model_pos, screen_pos);
+    return compute_gradient_fragment_color(
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+        model_pos,
+        screen_pos,
+    );
 }
 
 // Used by stencil-only passes that write no color. Color work is skipped entirely;
@@ -428,21 +456,36 @@ fn fs_stencil_only() -> @location(0) vec4<f32> {
 @fragment
 fn fs_passthrough(
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
 ) -> @location(0) vec4<f32> {
-    return compute_fragment_color(color, tex_coords, coverage, texture_flags);
+    return compute_fragment_color(
+        color,
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+    );
 }
 
 @fragment
 fn fs_passthrough_gradient(
     @location(0) color: vec4<f32>,
-    @location(1) tex_coords: vec2<f32>,
-    @location(2) coverage: f32,
-    @location(3) @interpolate(flat) texture_flags: f32,
-    @location(4) model_pos: vec2<f32>,
-    @location(5) screen_pos: vec2<f32>,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
+    @location(5) model_pos: vec2<f32>,
+    @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return compute_gradient_fragment_color(tex_coords, coverage, texture_flags, model_pos, screen_pos);
+    return compute_gradient_fragment_color(
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+        model_pos,
+        screen_pos,
+    );
 }

--- a/src/shaders/shader.wgsl
+++ b/src/shaders/shader.wgsl
@@ -326,10 +326,6 @@ fn vs_main_gradient(input: VertexInput) -> GradientVertexOutput {
     return output;
 }
 
-fn texture_coords_are_in_bounds(tex_coords: vec2<f32>) -> bool {
-    return all(tex_coords >= vec2<f32>(0.0, 0.0)) && all(tex_coords <= vec2<f32>(1.0, 1.0));
-}
-
 // Computes the final premultiplied color for a fragment given fill color, texture
 // coordinates, and AA coverage.
 fn compute_fragment_color(

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -55,6 +55,8 @@ pub struct CachedShapeHandle {
     pub(crate) is_rect: bool,
     /// The local-space bounding rect when `is_rect` is true, for scissor computation.
     pub(crate) rect_bounds: Option<[(f32, f32); 2]>,
+    /// Width and height of the local-space bounds used to normalize texture coordinates.
+    pub(crate) texture_mapping_size: [f32; 2],
     pub(crate) geometry_id: Option<u64>,
 }
 
@@ -86,13 +88,54 @@ impl CachedShapeHandle {
             TessellatedGeometry::Owned(vertex_buffers) => Arc::new(vertex_buffers),
             TessellatedGeometry::Shared(vertex_buffers) => vertex_buffers,
         };
+        let texture_mapping_size = rect_bounds
+            .map(rect_size)
+            .unwrap_or_else(|| compute_texture_mapping_size(&vertices));
         Self {
             vertex_buffers: vertices,
             is_rect,
             rect_bounds,
+            texture_mapping_size,
             geometry_id,
         }
     }
+}
+
+fn rect_size(rect_bounds: [(f32, f32); 2]) -> [f32; 2] {
+    [
+        (rect_bounds[1].0 - rect_bounds[0].0).abs().max(1e-6),
+        (rect_bounds[1].1 - rect_bounds[0].1).abs().max(1e-6),
+    ]
+}
+
+fn compute_texture_mapping_size(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [f32; 2] {
+    if vertex_buffers.vertices.is_empty() {
+        return [1.0, 1.0];
+    }
+
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+
+    for vertex in &vertex_buffers.vertices {
+        let x = vertex.position[0];
+        let y = vertex.position[1];
+        if x < min_x {
+            min_x = x;
+        }
+        if y < min_y {
+            min_y = y;
+        }
+        if x > max_x {
+            max_x = x;
+        }
+        if y > max_y {
+            max_y = y;
+        }
+    }
+
+    [(max_x - min_x).max(1e-6), (max_y - min_y).max(1e-6)]
 }
 
 pub(crate) enum TessellatedGeometry {
@@ -1041,12 +1084,46 @@ impl PathShape {
     }
 }
 
+/// Controls how bound textures are fit into a shape's local texture-coordinate space.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub enum ShapeTextureFitMode {
+    /// Normalize the shape bounds to `[0, 1]` and stretch the texture to cover them fully.
+    #[default]
+    Stretch,
+    /// Treat one texture texel as one physical pixel before the shape transform is applied.
+    /// Translation does not affect the mapping, while scale, rotation, and perspective affect
+    /// the texture together with the shape. Sampling outside the original texture area uses
+    /// clamp-to-edge behavior, so textures should include a transparent 1px padding border for
+    /// the unclipped area to appear transparent as intended.
+    OriginalSize,
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct ShapeTextureOptions {
+    pub texture_id: Option<u64>,
+    pub fit_mode: ShapeTextureFitMode,
+}
+
+impl ShapeTextureOptions {
+    pub fn new(texture_id: u64) -> Self {
+        Self {
+            texture_id: Some(texture_id),
+            fit_mode: ShapeTextureFitMode::Stretch,
+        }
+    }
+
+    pub fn fit_mode(mut self, fit_mode: ShapeTextureFitMode) -> Self {
+        self.fit_mode = fit_mode;
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ShapeDrawCommandOptions {
     pub transform: Option<InstanceTransform>,
     pub clips_children: bool,
-    pub background_texture_id: Option<u64>,
-    pub foreground_texture_id: Option<u64>,
+    pub background_texture: ShapeTextureOptions,
+    pub foreground_texture: ShapeTextureOptions,
     pub fill: Option<Fill>,
 }
 
@@ -1055,8 +1132,8 @@ impl Default for ShapeDrawCommandOptions {
         Self {
             transform: None,
             clips_children: true,
-            background_texture_id: None,
-            foreground_texture_id: None,
+            background_texture: ShapeTextureOptions::default(),
+            foreground_texture: ShapeTextureOptions::default(),
             fill: None,
         }
     }
@@ -1077,13 +1154,45 @@ impl ShapeDrawCommandOptions {
         self
     }
 
+    pub fn background_texture(mut self, background_texture: ShapeTextureOptions) -> Self {
+        self.background_texture = background_texture;
+        self
+    }
+
+    pub fn foreground_texture(mut self, foreground_texture: ShapeTextureOptions) -> Self {
+        self.foreground_texture = foreground_texture;
+        self
+    }
+
     pub fn background_texture_id(mut self, background_texture_id: u64) -> Self {
-        self.background_texture_id = Some(background_texture_id);
+        self.background_texture.texture_id = Some(background_texture_id);
         self
     }
 
     pub fn foreground_texture_id(mut self, foreground_texture_id: u64) -> Self {
-        self.foreground_texture_id = Some(foreground_texture_id);
+        self.foreground_texture.texture_id = Some(foreground_texture_id);
+        self
+    }
+
+    pub fn texture_fit_mode(mut self, texture_fit_mode: ShapeTextureFitMode) -> Self {
+        self.background_texture.fit_mode = texture_fit_mode;
+        self.foreground_texture.fit_mode = texture_fit_mode;
+        self
+    }
+
+    pub fn background_texture_fit_mode(
+        mut self,
+        background_texture_fit_mode: ShapeTextureFitMode,
+    ) -> Self {
+        self.background_texture.fit_mode = background_texture_fit_mode;
+        self
+    }
+
+    pub fn foreground_texture_fit_mode(
+        mut self,
+        foreground_texture_fit_mode: ShapeTextureFitMode,
+    ) -> Self {
+        self.foreground_texture.fit_mode = foreground_texture_fit_mode;
         self
     }
 
@@ -1133,7 +1242,10 @@ impl CachedShapeDrawData {
             is_empty: false,
             // Data from options
             transform: options.transform,
-            texture_ids: [options.background_texture_id, options.foreground_texture_id],
+            texture_ids: [
+                options.background_texture.texture_id,
+                options.foreground_texture.texture_id,
+            ],
             clips_children: options.clips_children,
             color_override: match options.fill.as_ref() {
                 Some(Fill::Solid(color)) => Some(color.normalize()),

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1092,9 +1092,9 @@ pub enum ShapeTextureFitMode {
     Stretch,
     /// Treat one texture texel as one physical pixel before the shape transform is applied.
     /// Translation does not affect the mapping, while scale, rotation, and perspective affect
-    /// the texture together with the shape. Sampling outside the original texture area uses
-    /// clamp-to-edge behavior, so textures should include a transparent 1px padding border for
-    /// the unclipped area to appear transparent as intended.
+    /// the texture together with the shape. Outside the original texture footprint, sampling does
+    /// not crop to transparency; the unclipped area instead shows the underlying fill/background
+    /// according to normal compositing.
     OriginalSize,
 }
 

--- a/src/texture_manager.rs
+++ b/src/texture_manager.rs
@@ -315,6 +315,17 @@ impl TextureManager {
             .unwrap()
             .contains_key(&texture_id)
     }
+
+    pub(crate) fn texture_dimensions(&self, texture_id: u64) -> Option<(u32, u32)> {
+        self.texture_storage
+            .read()
+            .unwrap()
+            .get(&texture_id)
+            .map(|texture| {
+                let size = texture.size();
+                (size.width, size.height)
+            })
+    }
 }
 
 // Converts an RGBA8 sRGB image in-place to premultiplied alpha.

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -290,6 +290,8 @@ impl InstanceTransform {
 pub struct InstanceMetadata {
     pub draw_order: f32,
     pub texture_flags: f32,
+    pub texture_uv_scale_layer0: [f32; 2],
+    pub texture_uv_scale_layer1: [f32; 2],
 }
 
 impl Default for InstanceMetadata {
@@ -297,6 +299,8 @@ impl Default for InstanceMetadata {
         Self {
             draw_order: 0.0,
             texture_flags: 0.0,
+            texture_uv_scale_layer0: [1.0, 1.0],
+            texture_uv_scale_layer1: [1.0, 1.0],
         }
     }
 }
@@ -316,6 +320,16 @@ impl InstanceMetadata {
                     format: wgpu::VertexFormat::Float32,
                     offset: std::mem::size_of::<f32>() as wgpu::BufferAddress,
                     shader_location: 10,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x2,
+                    offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    shader_location: 11,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x2,
+                    offset: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    shader_location: 12,
                 },
             ],
         }

--- a/tests/visual_regression.rs
+++ b/tests/visual_regression.rs
@@ -10,9 +10,16 @@ use grafo_test_scenes::{build_main_scene, check_pixels, CANVAS_HEIGHT, CANVAS_WI
 /// Creates a headless renderer, returning `None` (and printing a skip message)
 /// when no suitable GPU adapter is available.
 fn create_headless_renderer() -> Option<grafo::Renderer<'static>> {
+    create_headless_renderer_with_size_and_scale((CANVAS_WIDTH, CANVAS_HEIGHT), 1.0)
+}
+
+fn create_headless_renderer_with_size_and_scale(
+    physical_size: (u32, u32),
+    scale_factor: f64,
+) -> Option<grafo::Renderer<'static>> {
     match block_on(grafo::Renderer::try_new_headless(
-        (CANVAS_WIDTH, CANVAS_HEIGHT),
-        1.0,
+        physical_size,
+        scale_factor,
     )) {
         Ok(r) => Some(r),
         Err(grafo::RendererCreationError::AdapterNotAvailable(_)) => {
@@ -110,6 +117,82 @@ fn single_root_no_children() {
     ];
 
     assert_pixels_match(&pixel_buffer, &expectations);
+}
+
+/// Regression test — OriginalSize texture fit uses physical pixels, not logical units.
+#[test]
+fn original_size_texture_fit_uses_physical_pixels_on_hidpi() {
+    let physical_size = (200, 200);
+    let scale_factor = 2.0;
+    let Some(mut renderer) =
+        create_headless_renderer_with_size_and_scale(physical_size, scale_factor)
+    else {
+        return;
+    };
+
+    let green_texture_id = 9_001u64;
+    let solid_green_20x20 = vec![255u8; 20 * 20 * 4]
+        .chunks_exact(4)
+        .flat_map(|_| [0u8, 255u8, 0u8, 255u8])
+        .collect::<Vec<_>>();
+    renderer.texture_manager().allocate_texture_with_data(
+        green_texture_id,
+        (20, 20),
+        &solid_green_20x20,
+    );
+
+    let shape = grafo::Shape::rect([(10.0, 10.0), (70.0, 70.0)], grafo::Stroke::default());
+    renderer
+        .add_shape(
+            shape,
+            None,
+            None,
+            grafo::ShapeDrawCommandOptions::new()
+                .background_texture(
+                    grafo::ShapeTextureOptions::new(green_texture_id)
+                        .fit_mode(grafo::ShapeTextureFitMode::OriginalSize),
+                )
+                .color(grafo::Color::WHITE),
+        )
+        .unwrap();
+
+    let mut pixel_buffer: Vec<u8> = Vec::new();
+    renderer.render_to_buffer(&mut pixel_buffer);
+
+    let expectations = vec![
+        grafo_test_scenes::PixelExpectation::opaque(
+            30,
+            30,
+            0,
+            255,
+            0,
+            "inside_20px_physical_texture_region",
+        ),
+        grafo_test_scenes::PixelExpectation::opaque(
+            60,
+            30,
+            255,
+            255,
+            255,
+            "outside_texture_region_inside_shape",
+        ),
+        grafo_test_scenes::PixelExpectation::transparent(5, 5, "outside_shape"),
+    ];
+
+    let failures = check_pixels(
+        &pixel_buffer,
+        physical_size.0,
+        physical_size.1,
+        &expectations,
+    );
+    if !failures.is_empty() {
+        let message = format!(
+            "{} pixel expectation(s) failed:\n{}",
+            failures.len(),
+            failures.join("\n"),
+        );
+        panic!("{message}");
+    }
 }
 
 /// Regression test — scissor-only clipping rect clips children without drawing itself.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `OriginalSize` texture fitting mode that preserves original texture dimensions instead of stretching to fill shapes.
  * Introduced enhanced texture configuration options for both background and foreground layers with per-layer fit mode control.
  * Texture rendering now correctly scales with shape transforms while maintaining proper clipping behavior outside scaled bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->