### PR TITLE
feat: add config for backdrop capture

### DIFF
--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -13,7 +13,7 @@
 /// `gaussian_blur` example, but applied as a *backdrop* effect rather than a
 /// *group* effect.
 use futures::executor::block_on;
-use grafo::{BorderRadii, Shape};
+use grafo::{BackdropEffectConfig, BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
 use winit::application::ApplicationHandler;
@@ -45,7 +45,7 @@ struct Params {
 
 @fragment
 fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    let pixel = DIRECTION / params.tex_size;
+    let pixel = DIRECTION / vec2<f32>(textureDimensions(t_input));
     let sigma = max(params.radius / 3.0, 0.001);
     var color = vec4<f32>(0.0);
     var total_weight = 0.0;
@@ -72,7 +72,7 @@ struct Params {
 
 @fragment
 fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    let pixel = DIRECTION / params.tex_size;
+    let pixel = DIRECTION / vec2<f32>(textureDimensions(t_input));
     let sigma = max(params.radius / 3.0, 0.001);
     var color = vec4<f32>(0.0);
     var total_weight = 0.0;
@@ -252,13 +252,14 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params = BlurParams {
                     radius: 12.0,
                     _pad: 0.0,
-                    tex_size: [pw as f32, ph as f32],
+                    tex_size: [400.0, 340.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(
                         panel_id,
                         BLUR_EFFECT,
                         bytemuck::bytes_of(&blur_params),
+                        BackdropEffectConfig::default().padding(blur_params.radius),
                     )
                     .expect("Failed to set backdrop effect");
 
@@ -279,13 +280,14 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params2 = BlurParams {
                     radius: 20.0,
                     _pad: 0.0,
-                    tex_size: [pw as f32, ph as f32],
+                    tex_size: [180.0, 200.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(
                         panel2_id,
                         BLUR_EFFECT,
                         bytemuck::bytes_of(&blur_params2),
+                        BackdropEffectConfig::default().padding(blur_params2.radius),
                     )
                     .expect("Failed to set backdrop effect");
 

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -30,7 +30,6 @@ const BLUR_EFFECT: u64 = 1;
 struct BlurParams {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: [f32; 2],
 }
 
 const HORIZONTAL_BLUR_WGSL: &str = r#"
@@ -39,7 +38,6 @@ const DIRECTION: vec2<f32> = vec2<f32>(1.0, 0.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -66,7 +64,6 @@ const DIRECTION: vec2<f32> = vec2<f32>(0.0, 1.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -252,7 +249,6 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params = BlurParams {
                     radius: 12.0,
                     _pad: 0.0,
-                    _unused_capture_size: [400.0, 340.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(
@@ -280,7 +276,6 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params2 = BlurParams {
                     radius: 20.0,
                     _pad: 0.0,
-                    _unused_capture_size: [180.0, 200.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -30,7 +30,7 @@ const BLUR_EFFECT: u64 = 1;
 struct BlurParams {
     radius: f32,
     _pad: f32,
-    tex_size: [f32; 2],
+    _unused_capture_size: [f32; 2],
 }
 
 const HORIZONTAL_BLUR_WGSL: &str = r#"
@@ -39,7 +39,7 @@ const DIRECTION: vec2<f32> = vec2<f32>(1.0, 0.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    tex_size: vec2<f32>,
+    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -66,7 +66,7 @@ const DIRECTION: vec2<f32> = vec2<f32>(0.0, 1.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    tex_size: vec2<f32>,
+    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -252,7 +252,7 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params = BlurParams {
                     radius: 12.0,
                     _pad: 0.0,
-                    tex_size: [400.0, 340.0],
+                    _unused_capture_size: [400.0, 340.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(
@@ -280,7 +280,7 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params2 = BlurParams {
                     radius: 20.0,
                     _pad: 0.0,
-                    tex_size: [180.0, 200.0],
+                    _unused_capture_size: [180.0, 200.0],
                 };
                 renderer
                     .set_shape_backdrop_effect(

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -100,7 +100,6 @@ fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 struct BlurParams {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: [f32; 2],
 }
 
 const HORIZONTAL_BLUR_WGSL: &str = r#"
@@ -109,7 +108,6 @@ const DIRECTION: vec2<f32> = vec2<f32>(1.0, 0.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -136,7 +134,6 @@ const DIRECTION: vec2<f32> = vec2<f32>(0.0, 1.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
@@ -353,7 +350,6 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params = BlurParams {
                     radius: 14.0,
                     _pad: 0.0,
-                    _unused_capture_size: [panel_w, panel_h],
                 };
                 renderer
                     .set_shape_backdrop_effect(

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -12,7 +12,7 @@
 ///
 /// Behind everything, colorful rectangles provide content for the blur to act on.
 use futures::executor::block_on;
-use grafo::{BorderRadii, Shape};
+use grafo::{BackdropEffectConfig, BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
 use winit::application::ApplicationHandler;
@@ -100,7 +100,7 @@ fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 struct BlurParams {
     radius: f32,
     _pad: f32,
-    tex_size: [f32; 2],
+    _unused_capture_size: [f32; 2],
 }
 
 const HORIZONTAL_BLUR_WGSL: &str = r#"
@@ -109,13 +109,13 @@ const DIRECTION: vec2<f32> = vec2<f32>(1.0, 0.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    tex_size: vec2<f32>,
+    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
 @fragment
 fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    let pixel = DIRECTION / params.tex_size;
+    let pixel = DIRECTION / vec2<f32>(textureDimensions(t_input));
     let sigma = max(params.radius / 3.0, 0.001);
     var color = vec4<f32>(0.0);
     var total_weight = 0.0;
@@ -136,13 +136,13 @@ const DIRECTION: vec2<f32> = vec2<f32>(0.0, 1.0);
 struct Params {
     radius: f32,
     _pad: f32,
-    tex_size: vec2<f32>,
+    _unused_capture_size: vec2<f32>,
 }
 @group(1) @binding(0) var<uniform> params: Params;
 
 @fragment
 fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
-    let pixel = DIRECTION / params.tex_size;
+    let pixel = DIRECTION / vec2<f32>(textureDimensions(t_input));
     let sigma = max(params.radius / 3.0, 0.001);
     var color = vec4<f32>(0.0);
     var total_weight = 0.0;
@@ -353,10 +353,15 @@ impl<'a> ApplicationHandler for App<'a> {
                 let blur_params = BlurParams {
                     radius: 14.0,
                     _pad: 0.0,
-                    tex_size: [pw, ph],
+                    _unused_capture_size: [panel_w, panel_h],
                 };
                 renderer
-                    .set_shape_backdrop_effect(glass, BLUR_EFFECT, bytemuck::bytes_of(&blur_params))
+                    .set_shape_backdrop_effect(
+                        glass,
+                        BLUR_EFFECT,
+                        bytemuck::bytes_of(&blur_params),
+                        BackdropEffectConfig::default().padding(blur_params.radius),
+                    )
                     .expect("Failed to set backdrop blur effect");
 
                 // ── Render ───────────────────────────────────────────────

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -3995,7 +3995,7 @@ fn tile_59_backdrop_node_bounds_offscreen_preserves_size(
         .unwrap();
 
     let blue_offscreen_band = Shape::rect(
-        [(ox + 80.0, oy + 15.0), (ox + 90.0, oy + 55.0)],
+        [(ox + 80.0, oy + 15.0), (ox + 170.0, oy + 55.0)],
         Stroke::default(),
     );
     renderer
@@ -4008,7 +4008,7 @@ fn tile_59_backdrop_node_bounds_offscreen_preserves_size(
         .unwrap();
 
     let yellow_offscreen_band = Shape::rect(
-        [(ox + 90.0, oy + 15.0), (ox + 100.0, oy + 55.0)],
+        [(ox + 170.0, oy + 15.0), (ox + 190.0, oy + 55.0)],
         Stroke::default(),
     );
     renderer
@@ -4021,7 +4021,7 @@ fn tile_59_backdrop_node_bounds_offscreen_preserves_size(
         .unwrap();
 
     let panel = Shape::rect(
-        [(ox + 60.0, oy + 15.0), (ox + 100.0, oy + 55.0)],
+        [(ox + 60.0, oy + 15.0), (ox + 190.0, oy + 55.0)],
         Stroke::default(),
     );
     let panel_id = renderer

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -1,24 +1,26 @@
 use grafo::{
-    BorderRadii, Color, ColorInterpolation, ConicGradientDesc, Fill, Gradient, GradientColor,
-    GradientCommonDesc, GradientStop, GradientStopOffset, GradientStopPositions, GradientUnits,
-    LinearGradientDesc, LinearGradientLine, RadialGradientDesc, RadialGradientShape,
-    RadialGradientSize, Renderer, Shape, ShapeDrawCommandOptions, ShapeTextureFitMode,
-    ShapeTextureOptions, SpreadMode, Stroke, TransformInstance,
+    BackdropCaptureArea, BackdropEffectConfig, BorderRadii, Color, ColorInterpolation,
+    ConicGradientDesc, Fill, Gradient, GradientColor, GradientCommonDesc, GradientStop,
+    GradientStopOffset, GradientStopPositions, GradientUnits, LinearGradientDesc,
+    LinearGradientLine, RadialGradientDesc, RadialGradientShape, RadialGradientSize, Renderer,
+    Shape, ShapeDrawCommandOptions, ShapeTextureFitMode, ShapeTextureOptions, SpreadMode, Stroke,
+    TransformInstance,
 };
 
 use crate::expectations::PixelExpectation;
-use crate::shaders::{BlurParams, HORIZONTAL_BLUR_WGSL, VERTICAL_BLUR_WGSL};
+use crate::shaders::{BlurParams, HORIZONTAL_BLUR_WGSL, PASSTHROUGH_WGSL, VERTICAL_BLUR_WGSL};
 
 // ── Grid layout constants ────────────────────────────────────────────────────
 
 const TILE_SIZE: u32 = 80;
 const COLUMNS: u32 = 6;
-const ROWS: u32 = 9;
+const ROWS: u32 = 10;
 
 pub const CANVAS_WIDTH: u32 = TILE_SIZE * COLUMNS;
 pub const CANVAS_HEIGHT: u32 = TILE_SIZE * ROWS;
 
 const BLUR_EFFECT_ID: u64 = 1;
+const PASSTHROUGH_EFFECT_ID: u64 = 2;
 const CHECKERBOARD_TEXTURE_ID: u64 = 100;
 const SOLID_GREEN_TEXTURE_ID: u64 = 101;
 const SOLID_GREEN_20X20_TEXTURE_ID: u64 = 102;
@@ -115,6 +117,15 @@ pub fn build_main_scene(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     expectations.extend(tile_52_backdrop_overflow_visible_children(renderer));
     expectations.extend(tile_53_texture_original_size(renderer));
     expectations.extend(tile_54_texture_original_size_scaled(renderer));
+    expectations.extend(tile_55_backdrop_capture_screen_rect(renderer));
+    expectations.extend(tile_56_backdrop_capture_downsampled(renderer));
+    expectations.extend(tile_57_gradient_backdrop_oversized_capture_falls_back(
+        renderer,
+    ));
+    expectations.extend(tile_58_backdrop_budgeted_capture_falls_back(renderer));
+    expectations.extend(tile_59_backdrop_node_bounds_offscreen_preserves_size(
+        renderer,
+    ));
 
     expectations
 }
@@ -125,6 +136,9 @@ fn load_shared_resources(renderer: &mut Renderer) {
     renderer
         .load_effect(BLUR_EFFECT_ID, &[HORIZONTAL_BLUR_WGSL, VERTICAL_BLUR_WGSL])
         .expect("Failed to compile blur effect");
+    renderer
+        .load_effect(PASSTHROUGH_EFFECT_ID, &[PASSTHROUGH_WGSL])
+        .expect("Failed to compile passthrough effect");
 
     // 4×4 checkerboard: alternating white and black pixels, RGBA
     let mut checkerboard = [0u8; 4 * 4 * 4];
@@ -1852,18 +1866,22 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
         )
         .unwrap();
 
-    let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
         radius: 10.0,
         _pad: 0.0,
-        tex_size: [pw as f32, ph as f32],
+        tex_size: [40.0, 50.0],
     };
     renderer
-        .set_shape_backdrop_effect(panel_id, BLUR_EFFECT_ID, bytemuck::bytes_of(&blur_params))
+        .set_shape_backdrop_effect(
+            panel_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&blur_params),
+            BackdropEffectConfig::default(),
+        )
         .expect("Failed to set backdrop effect");
 
     vec![
-        // Panel interior: blurred mix of red bg + blue stripe + white overlay
+        // Panel interior: blurred mix of red bg + blue stripe under the panel's white fill
         PixelExpectation::new(
             ox as u32 + 40,
             oy as u32 + 40,
@@ -1873,7 +1891,7 @@ fn tile_29_backdrop_blur_leaf(renderer: &mut Renderer) -> Vec<PixelExpectation> 
             255,
             "t29_backdrop_interior",
         )
-        .with_tolerance(40),
+        .with_tolerance(20),
         // Blue stripe outside panel stays sharp and fully blue
         PixelExpectation::opaque(
             ox as u32 + 12,
@@ -1945,14 +1963,18 @@ fn tile_30_backdrop_blur_nonleaf(renderer: &mut Renderer) -> Vec<PixelExpectatio
         )
         .unwrap();
 
-    let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
         radius: 8.0,
         _pad: 0.0,
-        tex_size: [pw as f32, ph as f32],
+        tex_size: [50.0, 60.0],
     };
     renderer
-        .set_shape_backdrop_effect(panel_id, BLUR_EFFECT_ID, bytemuck::bytes_of(&blur_params))
+        .set_shape_backdrop_effect(
+            panel_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&blur_params),
+            BackdropEffectConfig::default(),
+        )
         .expect("Failed to set backdrop effect");
 
     vec![
@@ -2037,18 +2059,22 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
         )
         .unwrap();
 
-    let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
         radius: 6.0,
         _pad: 0.0,
-        tex_size: [pw as f32, ph as f32],
+        tex_size: [40.0, 50.0],
     };
     renderer
-        .set_shape_backdrop_effect(panel_id, BLUR_EFFECT_ID, bytemuck::bytes_of(&blur_params))
+        .set_shape_backdrop_effect(
+            panel_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&blur_params),
+            BackdropEffectConfig::default(),
+        )
         .expect("Failed to set backdrop effect");
 
     vec![
-        // Panel interior: blurred mix of yellow bg + blue stripe + white overlay
+        // Panel interior: blurred mix of yellow bg + blue stripe under the panel's white fill
         PixelExpectation::new(
             ox as u32 + 35,
             oy as u32 + 40,
@@ -2058,7 +2084,7 @@ fn tile_31_backdrop_under_scissor(renderer: &mut Renderer) -> Vec<PixelExpectati
             255,
             "t31_backdrop_in_scissor",
         )
-        .with_tolerance(40),
+        .with_tolerance(20),
         // Blue stripe outside panel stays sharp
         PixelExpectation::opaque(
             ox as u32 + 65,
@@ -2976,28 +3002,32 @@ fn tile_46_gradient_backdrop_blur(renderer: &mut Renderer) -> Vec<PixelExpectati
         )
         .unwrap();
 
-    let (pw, ph) = renderer.size();
     let blur_params = BlurParams {
         radius: 10.0,
         _pad: 0.0,
-        tex_size: [pw as f32, ph as f32],
+        tex_size: [40.0, 50.0],
     };
     renderer
-        .set_shape_backdrop_effect(panel_id, BLUR_EFFECT_ID, bytemuck::bytes_of(&blur_params))
+        .set_shape_backdrop_effect(
+            panel_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&blur_params),
+            BackdropEffectConfig::default(),
+        )
         .expect("Failed to set backdrop effect");
 
     vec![
-        // Panel interior: blurred mix of red bg + gradient stripe + white overlay
+        // Panel interior: blurred mix of red bg + gradient stripe under the panel's white fill
         PixelExpectation::new(
             ox as u32 + 40,
             oy as u32 + 40,
-            150,
-            150,
-            180,
+            158,
+            185,
+            183,
             255,
             "t46_backdrop_interior",
         )
-        .with_tolerance(50),
+        .with_tolerance(25),
         // Gradient stripe outside panel — should be crisp blue (left side)
         PixelExpectation::opaque(
             ox as u32 + 12,
@@ -3463,14 +3493,18 @@ fn tile_52_backdrop_overflow_visible_children(renderer: &mut Renderer) -> Vec<Pi
         )
         .unwrap();
 
-    let (width, height) = renderer.size();
     let blur_params = BlurParams {
         radius: 5.0,
         _pad: 0.0,
-        tex_size: [width as f32, height as f32],
+        tex_size: [30.0, 30.0],
     };
     renderer
-        .set_shape_backdrop_effect(panel_id, BLUR_EFFECT_ID, bytemuck::bytes_of(&blur_params))
+        .set_shape_backdrop_effect(
+            panel_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&blur_params),
+            BackdropEffectConfig::default(),
+        )
         .expect("Failed to set backdrop effect");
 
     let child = Shape::rect(
@@ -3621,6 +3655,412 @@ fn tile_54_texture_original_size_scaled(renderer: &mut Renderer) -> Vec<PixelExp
             255,
             255,
             "t54_scaled_original_size_texture_clipped_outside_scaled_shape",
+        ),
+    ]
+}
+
+fn tile_55_backdrop_capture_screen_rect(renderer: &mut Renderer) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(55);
+
+    let red_source = Shape::rect(
+        [(ox + 5.0, oy + 10.0), (ox + 35.0, oy + 40.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            red_source,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(220, 50, 50)),
+        )
+        .unwrap();
+
+    let blue_behind_panel = Shape::rect(
+        [(ox + 45.0, oy + 20.0), (ox + 75.0, oy + 50.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            blue_behind_panel,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(50, 50, 220)),
+        )
+        .unwrap();
+
+    let panel = Shape::rect(
+        [(ox + 45.0, oy + 20.0), (ox + 75.0, oy + 50.0)],
+        Stroke::default(),
+    );
+    let panel_id = renderer
+        .add_shape(panel, None, None, ShapeDrawCommandOptions::new())
+        .unwrap();
+
+    renderer
+        .set_shape_backdrop_effect(
+            panel_id,
+            PASSTHROUGH_EFFECT_ID,
+            &[],
+            BackdropEffectConfig::new()
+                .capture_area(BackdropCaptureArea::ScreenRect([
+                    (ox + 5.0, oy + 10.0),
+                    (ox + 35.0, oy + 40.0),
+                ]))
+                .downsample(1.0),
+        )
+        .expect("Failed to set backdrop screen-rect effect");
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 60,
+            oy as u32 + 35,
+            220,
+            50,
+            50,
+            "t55_panel_uses_captured_rect",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 40,
+            oy as u32 + 35,
+            255,
+            255,
+            255,
+            "t55_outside_panel_stays_canvas_bg",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 20,
+            oy as u32 + 25,
+            220,
+            50,
+            50,
+            "t55_source_rect_stays_red",
+        ),
+    ]
+}
+
+fn tile_56_backdrop_capture_downsampled(renderer: &mut Renderer) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(56);
+
+    let green_source = Shape::rect(
+        [(ox + 5.0, oy + 10.0), (ox + 45.0, oy + 50.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            green_source,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(50, 180, 50)),
+        )
+        .unwrap();
+
+    let red_behind_panel = Shape::rect(
+        [(ox + 50.0, oy + 15.0), (ox + 75.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            red_behind_panel,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(220, 50, 50)),
+        )
+        .unwrap();
+
+    let panel = Shape::rect(
+        [(ox + 50.0, oy + 15.0), (ox + 75.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    let panel_id = renderer
+        .add_shape(panel, None, None, ShapeDrawCommandOptions::new())
+        .unwrap();
+
+    renderer
+        .set_shape_backdrop_effect(
+            panel_id,
+            PASSTHROUGH_EFFECT_ID,
+            &[],
+            BackdropEffectConfig::new()
+                .capture_area(BackdropCaptureArea::ScreenRect([
+                    (ox + 5.0, oy + 10.0),
+                    (ox + 45.0, oy + 50.0),
+                ]))
+                .downsample(0.5),
+        )
+        .expect("Failed to set downsampled backdrop effect");
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 62,
+            oy as u32 + 35,
+            50,
+            180,
+            50,
+            "t56_downsampled_panel_stays_green",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 47,
+            oy as u32 + 35,
+            255,
+            255,
+            255,
+            "t56_gap_between_source_and_panel_is_canvas_bg",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 20,
+            oy as u32 + 25,
+            50,
+            180,
+            50,
+            "t56_source_rect_stays_green",
+        ),
+    ]
+}
+
+fn tile_57_gradient_backdrop_oversized_capture_falls_back(
+    renderer: &mut Renderer,
+) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(57);
+
+    let panel = Shape::rect(
+        [(ox + 10.0, oy + 10.0), (ox + 70.0, oy + 70.0)],
+        Stroke::default(),
+    );
+    let gradient = Gradient::linear(LinearGradientDesc {
+        common: two_stop_common((220, 30, 30), (30, 30, 220), SpreadMode::Pad),
+        line: LinearGradientLine {
+            start: [ox + 10.0, oy + 40.0],
+            end: [ox + 70.0, oy + 40.0],
+        },
+    })
+    .expect("valid gradient");
+
+    let panel_id = renderer
+        .add_shape(
+            panel,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().fill(Fill::Gradient(gradient)),
+        )
+        .unwrap();
+
+    renderer
+        .set_shape_backdrop_effect(
+            panel_id,
+            PASSTHROUGH_EFFECT_ID,
+            &[],
+            BackdropEffectConfig::new().capture_area(BackdropCaptureArea::ScreenRect([
+                (0.0, 0.0),
+                (20_000.0, 20_000.0),
+            ])),
+        )
+        .expect("Failed to set oversized gradient backdrop effect");
+
+    vec![
+        PixelExpectation::opaque_approx(
+            ox as u32 + 20,
+            oy as u32 + 40,
+            190,
+            30,
+            60,
+            60,
+            "t57_left_side_remains_gradient_red",
+        ),
+        PixelExpectation::opaque_approx(
+            ox as u32 + 60,
+            oy as u32 + 40,
+            60,
+            30,
+            190,
+            60,
+            "t57_right_side_remains_gradient_blue",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 5,
+            oy as u32 + 5,
+            255,
+            255,
+            255,
+            "t57_outside_panel_stays_canvas_bg",
+        ),
+    ]
+}
+
+fn tile_58_backdrop_budgeted_capture_falls_back(renderer: &mut Renderer) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(58);
+
+    let red_source = Shape::rect(
+        [(ox + 5.0, oy + 10.0), (ox + 75.0, oy + 45.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            red_source,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(220, 50, 50)),
+        )
+        .unwrap();
+
+    let blue_behind_panel = Shape::rect(
+        [(ox + 45.0, oy + 20.0), (ox + 75.0, oy + 50.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            blue_behind_panel,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(50, 50, 220)),
+        )
+        .unwrap();
+
+    let panel = Shape::rect(
+        [(ox + 45.0, oy + 20.0), (ox + 75.0, oy + 50.0)],
+        Stroke::default(),
+    );
+    let panel_id = renderer
+        .add_shape(panel, None, None, ShapeDrawCommandOptions::new())
+        .unwrap();
+
+    renderer
+        .set_shape_backdrop_effect(
+            panel_id,
+            PASSTHROUGH_EFFECT_ID,
+            &[],
+            BackdropEffectConfig::new().capture_area(BackdropCaptureArea::ScreenRect([
+                (ox + 5.0, oy + 10.0),
+                (ox + 1_505.0, oy + 1_510.0),
+            ])),
+        )
+        .expect("Failed to set budgeted backdrop effect");
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 60,
+            oy as u32 + 35,
+            50,
+            50,
+            220,
+            "t58_panel_stays_underlying_blue_when_capture_budget_skips",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 20,
+            oy as u32 + 25,
+            220,
+            50,
+            50,
+            "t58_source_rect_stays_red",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 40,
+            oy as u32 + 60,
+            255,
+            255,
+            255,
+            "t58_outside_panel_stays_canvas_bg",
+        ),
+    ]
+}
+
+fn tile_59_backdrop_node_bounds_offscreen_preserves_size(
+    renderer: &mut Renderer,
+) -> Vec<PixelExpectation> {
+    let (ox, oy) = tile_origin(59);
+
+    let red_band = Shape::rect(
+        [(ox + 60.0, oy + 15.0), (ox + 70.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            red_band,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(220, 50, 50)),
+        )
+        .unwrap();
+
+    let green_band = Shape::rect(
+        [(ox + 70.0, oy + 15.0), (ox + 80.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            green_band,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(50, 180, 50)),
+        )
+        .unwrap();
+
+    let blue_offscreen_band = Shape::rect(
+        [(ox + 80.0, oy + 15.0), (ox + 90.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            blue_offscreen_band,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(50, 50, 220)),
+        )
+        .unwrap();
+
+    let yellow_offscreen_band = Shape::rect(
+        [(ox + 90.0, oy + 15.0), (ox + 100.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            yellow_offscreen_band,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(220, 200, 50)),
+        )
+        .unwrap();
+
+    let panel = Shape::rect(
+        [(ox + 60.0, oy + 15.0), (ox + 100.0, oy + 55.0)],
+        Stroke::default(),
+    );
+    let panel_id = renderer
+        .add_shape(panel, None, None, ShapeDrawCommandOptions::new())
+        .unwrap();
+
+    renderer
+        .set_shape_backdrop_effect(
+            panel_id,
+            PASSTHROUGH_EFFECT_ID,
+            &[],
+            BackdropEffectConfig::default(),
+        )
+        .expect("Failed to set offscreen node-bounds backdrop effect");
+
+    vec![
+        PixelExpectation::opaque(
+            ox as u32 + 65,
+            oy as u32 + 35,
+            220,
+            50,
+            50,
+            "t59_visible_left_half_stays_red",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 75,
+            oy as u32 + 35,
+            50,
+            180,
+            50,
+            "t59_visible_right_half_stays_green",
+        ),
+        PixelExpectation::opaque(
+            ox as u32 + 55,
+            oy as u32 + 35,
+            255,
+            255,
+            255,
+            "t59_outside_panel_stays_canvas_bg",
         ),
     ]
 }

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -4055,6 +4055,14 @@ fn tile_59_backdrop_node_bounds_offscreen_preserves_size(
             "t59_visible_right_half_stays_green",
         ),
         PixelExpectation::opaque(
+            ox as u32 + 85,
+            oy as u32 + 35,
+            50,
+            50,
+            220,
+            "t59_preserves_size_middle_is_blue",
+        ),
+        PixelExpectation::opaque(
             ox as u32 + 55,
             oy as u32 + 35,
             255,

--- a/grafo-test-scenes/src/shaders.rs
+++ b/grafo-test-scenes/src/shaders.rs
@@ -64,3 +64,11 @@ pub struct BlurParams {
     pub _pad: f32,
     pub tex_size: [f32; 2],
 }
+
+/// Single-pass no-op effect used to validate backdrop capture placement without blur math.
+pub const PASSTHROUGH_WGSL: &str = r#"
+@fragment
+fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    return textureSample(t_input, s_input, uv);
+}
+"#;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,9 +4,16 @@ use lyon::tessellation::VertexBuffers;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+#[derive(Debug)]
+pub(crate) struct CachedTessellation {
+    pub(crate) vertex_buffers: Arc<VertexBuffers<CustomVertex, u16>>,
+    pub(crate) local_bounds: [(f32, f32); 2],
+    pub(crate) texture_mapping_size: [f32; 2],
+}
+
 pub(crate) struct Cache {
-    previous_frame: HashMap<u64, Arc<VertexBuffers<CustomVertex, u16>>>,
-    current_frame: HashMap<u64, Arc<VertexBuffers<CustomVertex, u16>>>,
+    previous_frame: HashMap<u64, Arc<CachedTessellation>>,
+    current_frame: HashMap<u64, Arc<CachedTessellation>>,
 }
 
 impl Cache {
@@ -24,34 +31,34 @@ impl Cache {
     pub(crate) fn get_vertex_buffers(
         &mut self,
         cache_key: &u64,
-    ) -> Option<Arc<VertexBuffers<CustomVertex, u16>>> {
-        if let Some(vertex_buffers) = self.current_frame.get(cache_key) {
-            return Some(Arc::clone(vertex_buffers));
+    ) -> Option<Arc<CachedTessellation>> {
+        if let Some(tessellation) = self.current_frame.get(cache_key) {
+            return Some(Arc::clone(tessellation));
         }
 
-        let vertex_buffers = self.previous_frame.get(cache_key)?.clone();
+        let tessellation = Arc::clone(self.previous_frame.get(cache_key)?);
         self.current_frame
             .entry(*cache_key)
-            .or_insert_with(|| Arc::clone(&vertex_buffers));
-        Some(vertex_buffers)
+            .or_insert_with(|| Arc::clone(&tessellation));
+        Some(tessellation)
     }
 
     pub(crate) fn insert_vertex_buffers(
         &mut self,
         cache_key: u64,
-        vertex_buffers: Arc<VertexBuffers<CustomVertex, u16>>,
+        tessellation: Arc<CachedTessellation>,
     ) {
-        self.current_frame.insert(cache_key, vertex_buffers);
+        self.current_frame.insert(cache_key, tessellation);
     }
 
     pub(crate) fn refresh_vertex_buffers(
         &mut self,
         cache_key: u64,
-        vertex_buffers: &Arc<VertexBuffers<CustomVertex, u16>>,
+        tessellation: &Arc<CachedTessellation>,
     ) {
         self.current_frame
             .entry(cache_key)
-            .or_insert_with(|| Arc::clone(vertex_buffers));
+            .or_insert_with(|| Arc::clone(tessellation));
     }
 
     pub(crate) fn end_frame(&mut self) {
@@ -62,7 +69,7 @@ impl Cache {
 
 #[cfg(test)]
 mod tests {
-    use super::Cache;
+    use super::{Cache, CachedTessellation};
     use crate::vertex::CustomVertex;
     use lyon::tessellation::VertexBuffers;
     use std::num::NonZeroUsize;
@@ -81,34 +88,64 @@ mod tests {
         vertex_buffers.indices.push(0);
 
         let shared_vertex_buffers = Arc::new(vertex_buffers);
-        cache.insert_vertex_buffers(7, shared_vertex_buffers.clone());
+        cache.insert_vertex_buffers(
+            7,
+            Arc::new(CachedTessellation {
+                vertex_buffers: shared_vertex_buffers.clone(),
+                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
+                texture_mapping_size: [1.0, 1.0],
+            }),
+        );
 
         let cached_vertex_buffers = cache.get_vertex_buffers(&7).unwrap();
-        assert!(Arc::ptr_eq(&shared_vertex_buffers, &cached_vertex_buffers));
+        assert!(Arc::ptr_eq(
+            &shared_vertex_buffers,
+            &cached_vertex_buffers.vertex_buffers
+        ));
     }
 
     #[test]
     fn cache_promotes_previous_frame_hits_into_current_frame() {
         let mut cache = Cache::new(NonZeroUsize::new(4).unwrap());
         let shared_vertex_buffers = Arc::new(VertexBuffers::<CustomVertex, u16>::new());
-        cache.insert_vertex_buffers(7, Arc::clone(&shared_vertex_buffers));
+        cache.insert_vertex_buffers(
+            7,
+            Arc::new(CachedTessellation {
+                vertex_buffers: Arc::clone(&shared_vertex_buffers),
+                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
+                texture_mapping_size: [1.0, 1.0],
+            }),
+        );
 
         cache.end_frame();
 
         let cached_vertex_buffers = cache.get_vertex_buffers(&7).unwrap();
-        assert!(Arc::ptr_eq(&shared_vertex_buffers, &cached_vertex_buffers));
+        assert!(Arc::ptr_eq(
+            &shared_vertex_buffers,
+            &cached_vertex_buffers.vertex_buffers
+        ));
 
         cache.end_frame();
 
         let cached_vertex_buffers = cache.get_vertex_buffers(&7).unwrap();
-        assert!(Arc::ptr_eq(&shared_vertex_buffers, &cached_vertex_buffers));
+        assert!(Arc::ptr_eq(
+            &shared_vertex_buffers,
+            &cached_vertex_buffers.vertex_buffers
+        ));
     }
 
     #[test]
     fn cache_drops_entries_not_used_for_a_frame() {
         let mut cache = Cache::new(NonZeroUsize::new(4).unwrap());
         let shared_vertex_buffers = Arc::new(VertexBuffers::<CustomVertex, u16>::new());
-        cache.insert_vertex_buffers(7, shared_vertex_buffers);
+        cache.insert_vertex_buffers(
+            7,
+            Arc::new(CachedTessellation {
+                vertex_buffers: shared_vertex_buffers,
+                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
+                texture_mapping_size: [1.0, 1.0],
+            }),
+        );
 
         cache.end_frame();
         cache.end_frame();
@@ -121,10 +158,20 @@ mod tests {
         let mut cache = Cache::new(NonZeroUsize::new(4).unwrap());
         let shared_vertex_buffers = Arc::new(VertexBuffers::<CustomVertex, u16>::new());
 
-        cache.refresh_vertex_buffers(7, &shared_vertex_buffers);
+        cache.refresh_vertex_buffers(
+            7,
+            &Arc::new(CachedTessellation {
+                vertex_buffers: shared_vertex_buffers.clone(),
+                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
+                texture_mapping_size: [1.0, 1.0],
+            }),
+        );
         cache.end_frame();
 
         let cached_vertex_buffers = cache.get_vertex_buffers(&7).unwrap();
-        assert!(Arc::ptr_eq(&shared_vertex_buffers, &cached_vertex_buffers));
+        assert!(Arc::ptr_eq(
+            &shared_vertex_buffers,
+            &cached_vertex_buffers.vertex_buffers
+        ));
     }
 }

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -33,6 +33,64 @@ pub enum EffectError {
     InvalidParams(String),
 }
 
+/// Defines which already-rendered region a backdrop effect captures before processing it.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub enum BackdropCaptureArea {
+    /// Capture the effect-bearing node's transformed local bounds.
+    #[default]
+    NodeBounds,
+    /// Capture the entire viewport.
+    FullScene,
+    /// Capture an explicit logical screen-space rectangle.
+    ScreenRect([(f32, f32); 2]),
+}
+
+/// Per-node configuration for backdrop capture before the effect shader runs.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct BackdropEffectConfig {
+    /// Which logical screen-space region should be captured from what has already rendered.
+    pub capture_area: BackdropCaptureArea,
+    /// Additional logical screen-space padding applied around the requested capture area.
+    ///
+    /// This is most useful for blur-like effects that need pixels outside the node bounds to
+    /// avoid clipped edges.
+    pub padding: f32,
+    /// Scale factor applied to the captured region before running the effect.
+    /// `1.0` keeps full resolution, `0.5` halves each axis, and so on.
+    pub downsample: f32,
+}
+
+impl Default for BackdropEffectConfig {
+    fn default() -> Self {
+        Self {
+            capture_area: BackdropCaptureArea::NodeBounds,
+            padding: 0.0,
+            downsample: 1.0,
+        }
+    }
+}
+
+impl BackdropEffectConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn capture_area(mut self, capture_area: BackdropCaptureArea) -> Self {
+        self.capture_area = capture_area;
+        self
+    }
+
+    pub fn padding(mut self, padding: f32) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    pub fn downsample(mut self, downsample: f32) -> Self {
+        self.downsample = downsample;
+        self
+    }
+}
+
 // ── Built-in shaders ─────────────────────────────────────────────────────────
 
 /// Built-in vertex shader for drawing a fullscreen triangle (3 vertices, no vertex buffer).
@@ -110,15 +168,25 @@ pub(crate) struct EffectInstance {
     pub params_buffer: Option<wgpu::Buffer>,
     /// Bind group for the parameters (group 1).
     pub params_bind_group: Option<wgpu::BindGroup>,
+    /// Optional backdrop capture configuration. Only used for backdrop effects.
+    pub backdrop_config: Option<BackdropEffectConfig>,
+    /// Persistent uniform buffer for backdrop material params bound at group 3 binding 0.
+    pub backdrop_material_params_buffer: Option<wgpu::Buffer>,
+    /// Cached backdrop bind group reused while the captured output texture identity is stable.
+    pub backdrop_texture_bind_group: Option<wgpu::BindGroup>,
+    /// Stable id of the pooled texture currently referenced by `backdrop_texture_bind_group`.
+    pub backdrop_texture_id: Option<u64>,
 }
 
 // ── Offscreen texture pool ───────────────────────────────────────────────────
 
-/// A pooled offscreen texture with color, depth/stencil, and optional MSAA resolve resources.
+/// A pooled offscreen texture with color, optional depth/stencil, and optional MSAA resolve
+/// resources.
 pub(crate) struct PooledTexture {
+    pub texture_id: u64,
     pub color_texture: wgpu::Texture,
     pub color_view: wgpu::TextureView,
-    pub depth_stencil_view: wgpu::TextureView,
+    pub depth_stencil_view: Option<wgpu::TextureView>,
     pub resolve_texture: Option<wgpu::Texture>,
     pub resolve_view: Option<wgpu::TextureView>,
     pub width: u32,
@@ -130,6 +198,7 @@ pub(crate) struct PooledTexture {
 /// At frame start, all textures move back to `available`.
 pub(crate) struct OffscreenTexturePool {
     available: Vec<PooledTexture>,
+    next_texture_id: u64,
 }
 
 /// Maximum number of textures to keep in the pool.
@@ -139,6 +208,7 @@ impl OffscreenTexturePool {
     pub fn new() -> Self {
         Self {
             available: Vec::new(),
+            next_texture_id: 1,
         }
     }
 
@@ -162,10 +232,9 @@ impl OffscreenTexturePool {
         }
     }
 
-    /// Acquire a texture matching the given dimensions and sample count.
-    /// Reuses an existing one if possible, otherwise creates a new one.
-    /// Returns an owned PooledTexture (moved out of the pool).
-    pub fn acquire(
+    /// Acquire a texture matching the given dimensions and sample count, plus a depth/stencil
+    /// attachment for render passes that write depth or stencil.
+    pub fn acquire_with_depth(
         &mut self,
         device: &wgpu::Device,
         width: u32,
@@ -173,25 +242,56 @@ impl OffscreenTexturePool {
         format: wgpu::TextureFormat,
         sample_count: u32,
     ) -> PooledTexture {
-        let found = self
-            .available
-            .iter()
-            .position(|t| t.width == width && t.height == height && t.sample_count == sample_count);
-
-        if let Some(idx) = found {
-            self.available.swap_remove(idx)
-        } else {
-            Self::create_pooled_texture(device, width, height, format, sample_count)
-        }
+        self.acquire(device, width, height, format, sample_count, true)
     }
 
-    fn create_pooled_texture(
+    /// Acquire a color-only texture matching the given dimensions and sample count.
+    pub fn acquire_color_only(
+        &mut self,
         device: &wgpu::Device,
         width: u32,
         height: u32,
         format: wgpu::TextureFormat,
         sample_count: u32,
     ) -> PooledTexture {
+        self.acquire(device, width, height, format, sample_count, false)
+    }
+
+    fn acquire(
+        &mut self,
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+        sample_count: u32,
+        with_depth: bool,
+    ) -> PooledTexture {
+        let found = self.available.iter().position(|texture| {
+            texture.width == width
+                && texture.height == height
+                && texture.sample_count == sample_count
+                && texture.depth_stencil_view.is_some() == with_depth
+        });
+
+        if let Some(idx) = found {
+            self.available.swap_remove(idx)
+        } else {
+            self.create_pooled_texture(device, width, height, format, sample_count, with_depth)
+        }
+    }
+
+    fn create_pooled_texture(
+        &mut self,
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+        sample_count: u32,
+        with_depth: bool,
+    ) -> PooledTexture {
+        let texture_id = self.next_texture_id;
+        self.next_texture_id += 1;
+
         let color_texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("effect_offscreen_color"),
             size: wgpu::Extent3d {
@@ -205,27 +305,29 @@ impl OffscreenTexturePool {
             format,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_SRC,
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
         });
         let color_view = color_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let depth_stencil_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("effect_offscreen_depth_stencil"),
-            size: wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth24PlusStencil8,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
+        let depth_stencil_view = with_depth.then(|| {
+            let depth_stencil_texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("effect_offscreen_depth_stencil"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Depth24PlusStencil8,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            });
+            depth_stencil_texture.create_view(&wgpu::TextureViewDescriptor::default())
         });
-        let depth_stencil_view =
-            depth_stencil_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         // When MSAA is enabled, create a resolve target (non-MSAA) for effects to read from
         let (resolve_texture, resolve_view) = if sample_count > 1 {
@@ -242,7 +344,8 @@ impl OffscreenTexturePool {
                 format,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                     | wgpu::TextureUsages::TEXTURE_BINDING
-                    | wgpu::TextureUsages::COPY_SRC,
+                    | wgpu::TextureUsages::COPY_SRC
+                    | wgpu::TextureUsages::COPY_DST,
                 view_formats: &[],
             });
             let resolve_v = resolve_tex.create_view(&wgpu::TextureViewDescriptor::default());
@@ -252,6 +355,7 @@ impl OffscreenTexturePool {
         };
 
         PooledTexture {
+            texture_id,
             color_texture,
             color_view,
             depth_stencil_view,
@@ -547,6 +651,56 @@ pub(crate) fn compile_composite_pipeline(
     (pipeline, input_bgl)
 }
 
+/// Compile a fullscreen texture-sampling pipeline without stencil/depth usage.
+/// Used for capture downsampling before running the user effect shader.
+pub(crate) fn compile_texture_blit_pipeline(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+    input_bind_group_layout: &wgpu::BindGroupLayout,
+) -> wgpu::RenderPipeline {
+    let wgsl = build_composite_wgsl();
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("texture_blit_shader"),
+        source: wgpu::ShaderSource::Wgsl(wgsl.into()),
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("texture_blit_pipeline_layout"),
+        bind_group_layouts: &[input_bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("texture_blit_pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_quad"),
+            compilation_options: Default::default(),
+            buffers: &[],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_composite"),
+            compilation_options: Default::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            ..Default::default()
+        },
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    })
+}
+
 /// Create a bind group to sample a texture (for effect input or composite input).
 pub(crate) fn create_texture_sample_bind_group(
     device: &wgpu::Device,
@@ -569,6 +723,60 @@ pub(crate) fn create_texture_sample_bind_group(
             },
         ],
     })
+}
+
+pub(crate) fn create_backdrop_texture_sample_bind_group(
+    device: &wgpu::Device,
+    layout: &wgpu::BindGroupLayout,
+    material_params_buffer: &wgpu::Buffer,
+    texture_view: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+    label: Option<&str>,
+) -> wgpu::BindGroup {
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label,
+        layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: material_params_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::TextureView(texture_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: wgpu::BindingResource::Sampler(sampler),
+            },
+        ],
+    })
+}
+
+pub(crate) fn prepare_solid_backdrop_material_params_buffer(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    backdrop_material_params_buffer: &mut Option<wgpu::Buffer>,
+    sampling_uniform: crate::pipeline::BackdropSamplingUniform,
+) -> wgpu::Buffer {
+    let material_params =
+        crate::gradient::gpu::GpuMaterialParams::for_backdrop_sampling(sampling_uniform);
+
+    if let Some(existing_buffer) = backdrop_material_params_buffer.as_ref() {
+        queue.write_buffer(existing_buffer, 0, bytemuck::bytes_of(&material_params));
+    } else {
+        *backdrop_material_params_buffer = Some(crate::pipeline::create_buffer_init(
+            device,
+            Some("solid_backdrop_material_params_buffer"),
+            bytemuck::bytes_of(&material_params),
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        ));
+    }
+
+    backdrop_material_params_buffer
+        .as_ref()
+        .expect("backdrop material params buffer should be initialized")
+        .clone()
 }
 
 /// Create a bind group for effect parameter uniforms.

--- a/src/gradient/gpu.rs
+++ b/src/gradient/gpu.rs
@@ -2,12 +2,12 @@
 
 use super::types::{GradientData, GradientKind};
 
-/// GPU-side gradient parameters packed into a uniform/storage-friendly struct.
-/// Matches the WGSL `GradientParams` struct in shader.wgsl.
+/// GPU-side gradient-only parameters packed into a uniform-friendly struct.
+/// Matches the WGSL `GradientColorParams` struct in shader.wgsl.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[allow(dead_code)]
-pub(crate) struct GpuGradientParams {
+pub(crate) struct GpuGradientColorParams {
     // gradient_type: 1=linear, 2=radial, 3=conic, 0=none
     pub gradient_type: u32,
     // spread_mode: 0=pad, 1=repeat
@@ -42,7 +42,7 @@ pub(crate) struct GpuGradientParams {
     pub _padding: f32,
 }
 
-impl GpuGradientParams {
+impl GpuGradientColorParams {
     pub fn from_gradient_data(data: &GradientData) -> Self {
         let gradient_type = match data.kind {
             GradientKind::Linear => 1u32,
@@ -76,7 +76,7 @@ impl GpuGradientParams {
             (data.period_start, data.period_len)
         };
 
-        GpuGradientParams {
+        GpuGradientColorParams {
             gradient_type,
             spread_mode,
             units,
@@ -115,6 +115,79 @@ impl GpuGradientParams {
             ramp_end: 1.0,
             _padding: 0.0,
         }
+    }
+}
+
+/// GPU-side backdrop sampling metadata reused by both solid and gradient backdrop draws.
+/// Matches the WGSL `BackdropSamplingParams` struct in shader.wgsl.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub(crate) struct GpuBackdropSamplingParams {
+    pub capture_origin: [f32; 2],
+    pub inverse_capture_size: [f32; 2],
+}
+
+impl Default for GpuBackdropSamplingParams {
+    fn default() -> Self {
+        Self {
+            capture_origin: [0.0, 0.0],
+            inverse_capture_size: [1.0, 1.0],
+        }
+    }
+}
+
+impl GpuBackdropSamplingParams {
+    pub fn from_sampling_uniform(
+        sampling_uniform: crate::pipeline::BackdropSamplingUniform,
+    ) -> Self {
+        Self {
+            capture_origin: sampling_uniform.capture_origin,
+            inverse_capture_size: sampling_uniform.inverse_capture_size,
+        }
+    }
+}
+
+/// GPU-side material parameters bound at group 3 binding 0.
+///
+/// This uniform layout is shared across regular gradient fills and backdrop-capable pipelines.
+/// Solid backdrop draws leave `gradient` in its inert `none()` state and only populate
+/// `backdrop_sampling`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub(crate) struct GpuMaterialParams {
+    pub gradient: GpuGradientColorParams,
+    pub backdrop_sampling: GpuBackdropSamplingParams,
+}
+
+impl Default for GpuMaterialParams {
+    fn default() -> Self {
+        Self {
+            gradient: GpuGradientColorParams::none(),
+            backdrop_sampling: GpuBackdropSamplingParams::default(),
+        }
+    }
+}
+
+impl GpuMaterialParams {
+    pub fn from_gradient_data(data: &GradientData) -> Self {
+        Self {
+            gradient: GpuGradientColorParams::from_gradient_data(data),
+            backdrop_sampling: GpuBackdropSamplingParams::default(),
+        }
+    }
+
+    pub fn with_backdrop_sampling(
+        mut self,
+        sampling_uniform: crate::pipeline::BackdropSamplingUniform,
+    ) -> Self {
+        self.backdrop_sampling = GpuBackdropSamplingParams::from_sampling_uniform(sampling_uniform);
+        self
+    }
+
+    pub fn for_backdrop_sampling(
+        sampling_uniform: crate::pipeline::BackdropSamplingUniform,
+    ) -> Self {
+        Self::default().with_backdrop_sampling(sampling_uniform)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ mod shape;
 mod texture_manager;
 
 pub use color::Color;
-pub use effect::EffectError;
+pub use effect::{BackdropCaptureArea, BackdropEffectConfig, EffectError};
 pub use gradient::errors::GradientError;
 pub use gradient::types::{
     ColorInterpolation, ConicGradientDesc, Fill, Gradient, GradientColor, GradientCommonDesc,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -36,6 +36,34 @@ impl Uniforms {
     }
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct BackdropSamplingUniform {
+    pub capture_origin: [f32; 2],
+    pub inverse_capture_size: [f32; 2],
+}
+
+impl BackdropSamplingUniform {
+    pub fn new(capture_origin: (i32, i32), capture_size: (u32, u32)) -> Self {
+        Self {
+            capture_origin: [capture_origin.0 as f32, capture_origin.1 as f32],
+            inverse_capture_size: [
+                1.0 / capture_size.0.max(1) as f32,
+                1.0 / capture_size.1.max(1) as f32,
+            ],
+        }
+    }
+}
+
+impl Default for BackdropSamplingUniform {
+    fn default() -> Self {
+        Self {
+            capture_origin: [0.0, 0.0],
+            inverse_capture_size: [1.0, 1.0],
+        }
+    }
+}
+
 fn create_equal_increment_stencil_state() -> wgpu::StencilState {
     // In this stencil state we will only draw where the stencil value is equal to the reference value,
     //  and all outside areas are zeroed.
@@ -216,6 +244,90 @@ pub fn create_gradient_bind_group_layout(device: &Device) -> BindGroupLayout {
             },
         ],
         label: Some("gradient_bind_group_layout"),
+    })
+}
+
+pub fn create_backdrop_texture_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    multisampled: false,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 4,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+        label: Some("backdrop_texture_bind_group_layout"),
+    })
+}
+
+pub fn create_backdrop_gradient_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    multisampled: false,
+                    view_dimension: wgpu::TextureViewDimension::D1,
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    multisampled: false,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 4,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+        label: Some("backdrop_gradient_bind_group_layout"),
     })
 }
 
@@ -995,6 +1107,96 @@ pub fn create_stencil_keep_color_pipeline(
     })
 }
 
+pub fn create_backdrop_stencil_keep_color_pipeline(
+    device: &Device,
+    format: wgpu::TextureFormat,
+    sample_count: u32,
+    uniform_bgl: &wgpu::BindGroupLayout,
+    texture_bgl_layer0: &wgpu::BindGroupLayout,
+    texture_bgl_layer1: &wgpu::BindGroupLayout,
+    backdrop_texture_bgl: &wgpu::BindGroupLayout,
+) -> RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("backdrop_stencil_keep_color_shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("shaders/shader.wgsl").into()),
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("backdrop_stencil_keep_color_pipeline_layout"),
+        bind_group_layouts: &[
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            backdrop_texture_bgl,
+        ],
+        push_constant_ranges: &[],
+    });
+
+    let stencil_face = wgpu::StencilFaceState {
+        compare: wgpu::CompareFunction::Equal,
+        fail_op: wgpu::StencilOperation::Keep,
+        depth_fail_op: wgpu::StencilOperation::Keep,
+        pass_op: wgpu::StencilOperation::Keep,
+    };
+
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("backdrop_stencil_keep_color_pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            compilation_options: Default::default(),
+            buffers: &[
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
+            ],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_backdrop_passthrough"),
+            compilation_options: Default::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState {
+                    color: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::One,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                    alpha: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::One,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                }),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: wgpu::TextureFormat::Depth24PlusStencil8,
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
+            stencil: wgpu::StencilState {
+                front: stencil_face,
+                back: stencil_face,
+                read_mask: 0xff,
+                write_mask: 0x00,
+            },
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState {
+            count: sample_count,
+            mask: !0,
+            alpha_to_coverage_enabled: false,
+        },
+        multiview: None,
+        cache: None,
+    })
+}
+
 pub fn create_gradient_stencil_keep_color_pipeline(
     device: &Device,
     format: wgpu::TextureFormat,
@@ -1044,6 +1246,96 @@ pub fn create_gradient_stencil_keep_color_pipeline(
         fragment: Some(wgpu::FragmentState {
             module: &shader,
             entry_point: Some("fs_main_gradient"),
+            compilation_options: Default::default(),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState {
+                    color: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::One,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                    alpha: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::One,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                }),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: wgpu::TextureFormat::Depth24PlusStencil8,
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
+            stencil: wgpu::StencilState {
+                front: stencil_face,
+                back: stencil_face,
+                read_mask: 0xff,
+                write_mask: 0x00,
+            },
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState {
+            count: sample_count,
+            mask: !0,
+            alpha_to_coverage_enabled: false,
+        },
+        multiview: None,
+        cache: None,
+    })
+}
+
+pub fn create_backdrop_gradient_stencil_keep_color_pipeline(
+    device: &Device,
+    format: wgpu::TextureFormat,
+    sample_count: u32,
+    uniform_bgl: &wgpu::BindGroupLayout,
+    texture_bgl_layer0: &wgpu::BindGroupLayout,
+    texture_bgl_layer1: &wgpu::BindGroupLayout,
+    backdrop_gradient_bgl: &wgpu::BindGroupLayout,
+) -> RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("backdrop_gradient_stencil_keep_color_shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("shaders/shader.wgsl").into()),
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("backdrop_gradient_stencil_keep_color_pipeline_layout"),
+        bind_group_layouts: &[
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            backdrop_gradient_bgl,
+        ],
+        push_constant_ranges: &[],
+    });
+
+    let stencil_face = wgpu::StencilFaceState {
+        compare: wgpu::CompareFunction::Equal,
+        fail_op: wgpu::StencilOperation::Keep,
+        depth_fail_op: wgpu::StencilOperation::Keep,
+        pass_op: wgpu::StencilOperation::Keep,
+    };
+
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("backdrop_gradient_stencil_keep_color_pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main_gradient"),
+            compilation_options: Default::default(),
+            buffers: &[
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
+            ],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_backdrop_passthrough_gradient"),
             compilation_options: Default::default(),
             targets: &[Some(wgpu::ColorTargetState {
                 format,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -114,10 +114,14 @@ pub struct Renderer<'a> {
     /// Bind group layouts for shape texture layers (groups 1 and 2).
     shape_texture_bind_group_layout_background: Arc<wgpu::BindGroupLayout>,
     shape_texture_bind_group_layout_foreground: Arc<wgpu::BindGroupLayout>,
+    /// Bind group layout for backdrop textures (group 3, bindings 3 and 4).
+    backdrop_texture_bind_group_layout: Arc<wgpu::BindGroupLayout>,
     /// Monotonic counter to invalidate cached shape texture bind groups when the layout changes.
     shape_texture_layout_epoch: u64,
     /// Default transparent texture bind groups for both layers.
     default_shape_texture_bind_groups: [Arc<wgpu::BindGroup>; 2], // [background, foreground]
+    /// Default transparent bind group for backdrop sampling.
+    default_backdrop_texture_bind_group: Arc<wgpu::BindGroup>,
 
     /// Render pipeline for decrementing stencil values.
     decrementing_pipeline: Arc<wgpu::RenderPipeline>,
@@ -210,9 +214,8 @@ pub struct Renderer<'a> {
     effect_sampler: Option<wgpu::Sampler>,
 
     // ── Backdrop effect infrastructure ─────────────────────────────────
-    /// Snapshot texture for backdrop effects (copy of current render target).
-    backdrop_snapshot_texture: Option<wgpu::Texture>,
-    backdrop_snapshot_view: Option<wgpu::TextureView>,
+    /// Fullscreen sampling pipeline used to downsample a captured backdrop region.
+    texture_blit_pipeline: Option<wgpu::RenderPipeline>,
     /// Stencil-only pipeline: writes stencil but no color output.
     /// Used for Step 1 of the three-step backdrop draw.
     stencil_only_pipeline: Option<wgpu::RenderPipeline>,
@@ -233,6 +236,8 @@ pub struct Renderer<'a> {
     // ── Gradient fill infrastructure ───────────────────────────────────
     /// Bind group layout for gradient resources (group 3 in shader).
     gradient_bind_group_layout: wgpu::BindGroupLayout,
+    /// Bind group layout for gradient resources plus backdrop sampling.
+    backdrop_gradient_bind_group_layout: wgpu::BindGroupLayout,
     /// Monotonic counter to invalidate cached gradient bind groups when the layout changes.
     gradient_bind_group_layout_epoch: u64,
     /// Sampler for gradient ramp textures (nearest, clamp-to-edge).

--- a/src/renderer/construction.rs
+++ b/src/renderer/construction.rs
@@ -192,6 +192,10 @@ impl<'a> Renderer<'a> {
 
         let gradient_bind_group_layout =
             crate::pipeline::create_gradient_bind_group_layout(&device);
+        let backdrop_texture_bind_group_layout =
+            crate::pipeline::create_backdrop_texture_bind_group_layout(&device);
+        let backdrop_gradient_bind_group_layout =
+            crate::pipeline::create_backdrop_gradient_bind_group_layout(&device);
         let and_gradient_pipeline = crate::pipeline::create_gradient_increment_pipeline(
             &device,
             config.format,
@@ -241,6 +245,11 @@ impl<'a> Renderer<'a> {
             Self::create_default_shape_texture_bind_group(&device, &queue, &and_texture_bgl_layer0);
         let (default_shape_texture_bind_group_layer1, shape_texture_bind_group_layout_layer1) =
             Self::create_default_shape_texture_bind_group(&device, &queue, &and_texture_bgl_layer1);
+        let default_backdrop_texture_bind_group = Self::create_default_backdrop_texture_bind_group(
+            &device,
+            &queue,
+            &backdrop_texture_bind_group_layout,
+        );
 
         let mut renderer = Self {
             instance,
@@ -266,11 +275,13 @@ impl<'a> Renderer<'a> {
             shape_texture_bind_group_layout_foreground: Arc::new(
                 shape_texture_bind_group_layout_layer1,
             ),
+            backdrop_texture_bind_group_layout: Arc::new(backdrop_texture_bind_group_layout),
             shape_texture_layout_epoch: 0,
             default_shape_texture_bind_groups: [
                 Arc::new(default_shape_texture_bind_group_layer0),
                 Arc::new(default_shape_texture_bind_group_layer1),
             ],
+            default_backdrop_texture_bind_group: Arc::new(default_backdrop_texture_bind_group),
             decrementing_pipeline: Arc::new(decrementing_pipeline),
             decrementing_uniforms,
             decrementing_uniform_buffer,
@@ -320,8 +331,7 @@ impl<'a> Renderer<'a> {
             composite_pipeline: None,
             composite_bgl: None,
             effect_sampler: None,
-            backdrop_snapshot_texture: None,
-            backdrop_snapshot_view: None,
+            texture_blit_pipeline: None,
             stencil_only_pipeline: None,
             backdrop_color_pipeline: None,
             backdrop_color_gradient_pipeline: None,
@@ -329,6 +339,7 @@ impl<'a> Renderer<'a> {
             leaf_draw_gradient_pipeline: Arc::new(leaf_draw_gradient_pipeline),
             and_gradient_pipeline: Arc::new(and_gradient_pipeline),
             gradient_bind_group_layout,
+            backdrop_gradient_bind_group_layout,
             gradient_bind_group_layout_epoch: 0,
             gradient_ramp_sampler,
             #[cfg(feature = "render_metrics")]
@@ -543,6 +554,84 @@ impl<'a> Renderer<'a> {
         (bind_group, shape_texture_bind_group_layout.clone())
     }
 
+    fn create_default_backdrop_texture_bind_group(
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        backdrop_texture_bind_group_layout: &wgpu::BindGroupLayout,
+    ) -> wgpu::BindGroup {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("default_transparent_backdrop_texture"),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let transparent: [u8; 4] = [0, 0, 0, 0];
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &transparent,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4),
+                rows_per_image: Some(1),
+            },
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let material_params_buffer = crate::pipeline::create_buffer_init(
+            device,
+            Some("default_backdrop_material_params_buffer"),
+            bytemuck::bytes_of(&crate::gradient::gpu::GpuMaterialParams::default()),
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: backdrop_texture_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: material_params_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+            label: Some("default_backdrop_texture_bind_group_transparent"),
+        })
+    }
+
     pub async fn new_transparent(
         window: impl Into<SurfaceTarget<'static>>,
         physical_size: (u32, u32),
@@ -689,10 +778,15 @@ impl<'a> Renderer<'a> {
 
         self.shape_texture_bind_group_layout_background = Arc::new(and_texture_bgl_layer0);
         self.shape_texture_bind_group_layout_foreground = Arc::new(and_texture_bgl_layer1);
+        self.backdrop_texture_bind_group_layout = Arc::new(
+            crate::pipeline::create_backdrop_texture_bind_group_layout(&self.device),
+        );
         self.shape_texture_layout_epoch += 1;
 
         self.gradient_bind_group_layout =
             crate::pipeline::create_gradient_bind_group_layout(&self.device);
+        self.backdrop_gradient_bind_group_layout =
+            crate::pipeline::create_backdrop_gradient_bind_group_layout(&self.device);
         self.gradient_bind_group_layout_epoch += 1;
         self.gradient_ramp_sampler = self.device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("gradient_ramp_sampler"),
@@ -723,10 +817,16 @@ impl<'a> Renderer<'a> {
                 &self.queue,
                 &self.shape_texture_bind_group_layout_foreground,
             );
+        let default_backdrop_texture_bind_group = Self::create_default_backdrop_texture_bind_group(
+            &self.device,
+            &self.queue,
+            &self.backdrop_texture_bind_group_layout,
+        );
         self.default_shape_texture_bind_groups = [
             Arc::new(default_shape_texture_bind_group_background),
             Arc::new(default_shape_texture_bind_group_foreground),
         ];
+        self.default_backdrop_texture_bind_group = Arc::new(default_backdrop_texture_bind_group);
 
         self.composite_pipeline = None;
         self.composite_bgl = None;
@@ -752,6 +852,7 @@ impl<'a> Renderer<'a> {
         );
 
         // Reset lazily-created pipelines so they pick up the new layout
+        self.texture_blit_pipeline = None;
         self.stencil_only_pipeline = None;
         self.backdrop_color_pipeline = None;
         self.backdrop_color_gradient_pipeline = None;
@@ -768,6 +869,16 @@ impl<'a> Renderer<'a> {
                 &self.gradient_ramp_sampler,
                 self.gradient_bind_group_layout_epoch,
             );
+
+            if let crate::renderer::types::DrawCommand::CachedShape(cached_shape) = draw_command {
+                cached_shape.backdrop_gradient_bind_group = None;
+                cached_shape.backdrop_gradient_texture_id = None;
+            }
+        }
+
+        for effect_instance in self.backdrop_effects.values_mut() {
+            effect_instance.backdrop_texture_bind_group = None;
+            effect_instance.backdrop_texture_id = None;
         }
     }
 }

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -247,9 +247,20 @@ impl<'a> Renderer<'a> {
             return [1.0, 1.0];
         };
 
+        self.compute_texture_uv_scale_from_dimensions(
+            texture_mapping_size,
+            (texture_width, texture_height),
+        )
+    }
+
+    pub(super) fn compute_texture_uv_scale_from_dimensions(
+        &self,
+        texture_mapping_size: [f32; 2],
+        texture_dimensions: (u32, u32),
+    ) -> [f32; 2] {
         [
-            texture_mapping_size[0] * self.scale_factor as f32 / texture_width.max(1) as f32,
-            texture_mapping_size[1] * self.scale_factor as f32 / texture_height.max(1) as f32,
+            texture_mapping_size[0] * self.scale_factor as f32 / texture_dimensions.0.max(1) as f32,
+            texture_mapping_size[1] * self.scale_factor as f32 / texture_dimensions.1.max(1) as f32,
         ]
     }
 }

--- a/src/renderer/draw_queue.rs
+++ b/src/renderer/draw_queue.rs
@@ -132,7 +132,7 @@ impl<'a> Renderer<'a> {
             cached_shape_data.index_buffer_range = Some((index_start, index_count));
             cached_shape_data.is_empty = false;
             let texture_uv_scales = self.compute_texture_uv_scales(
-                cached_shape_data.cached_shape.texture_mapping_size,
+                cached_shape_data.cached_shape.texture_mapping_size(),
                 draw_options,
             );
             let instance_index = preparation::append_instance_data(
@@ -186,10 +186,7 @@ impl<'a> Renderer<'a> {
         if let Some(geometry_id) = cached_shape_data.cached_shape.geometry_id {
             self.buffers_pool_manager
                 .tessellation_cache
-                .refresh_vertex_buffers(
-                    geometry_id,
-                    &cached_shape_data.cached_shape.vertex_buffers,
-                );
+                .refresh_vertex_buffers(geometry_id, &cached_shape_data.cached_shape.tessellation);
         }
     }
 

--- a/src/renderer/effects.rs
+++ b/src/renderer/effects.rs
@@ -44,11 +44,45 @@ fn validate_effect_params(
     )
 }
 
+fn validate_backdrop_config(config: &effect::BackdropEffectConfig) -> Result<(), EffectError> {
+    if !(config.downsample > 0.0 && config.downsample <= 1.0) {
+        return Err(EffectError::InvalidParams(format!(
+            "backdrop downsample must be in the range (0.0, 1.0], got {}",
+            config.downsample
+        )));
+    }
+
+    if !config.padding.is_finite() || config.padding < 0.0 {
+        return Err(EffectError::InvalidParams(format!(
+            "backdrop padding must be finite and non-negative, got {}",
+            config.padding
+        )));
+    }
+
+    if let effect::BackdropCaptureArea::ScreenRect([(x0, y0), (x1, y1)]) = config.capture_area {
+        if !(x0.is_finite() && y0.is_finite() && x1.is_finite() && y1.is_finite()) {
+            return Err(EffectError::InvalidParams(
+                "backdrop screen capture rectangles must use only finite coordinates".to_string(),
+            ));
+        }
+
+        if !(x1 > x0 && y1 > y0) {
+            return Err(EffectError::InvalidParams(
+                "backdrop screen capture rectangles must have positive width and height"
+                    .to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn build_effect_instance(
     device: &wgpu::Device,
     loaded_effects: &HashMap<u64, LoadedEffect>,
     effect_id: u64,
     params: &[u8],
+    backdrop_config: Option<effect::BackdropEffectConfig>,
     params_buffer_label: &'static str,
 ) -> EffectInstance {
     let mut instance = EffectInstance {
@@ -56,6 +90,10 @@ fn build_effect_instance(
         params: params.to_vec(),
         params_buffer: None,
         params_bind_group: None,
+        backdrop_config,
+        backdrop_material_params_buffer: None,
+        backdrop_texture_bind_group: None,
+        backdrop_texture_id: None,
     };
 
     if params.is_empty() {
@@ -157,6 +195,7 @@ impl<'a> Renderer<'a> {
             &self.loaded_effects,
             effect_id,
             params,
+            None,
             "effect_params_buffer",
         );
 
@@ -197,6 +236,7 @@ impl<'a> Renderer<'a> {
         node_id: usize,
         effect_id: u64,
         params: &[u8],
+        backdrop_config: effect::BackdropEffectConfig,
     ) -> Result<(), EffectError> {
         if self.draw_tree.get(node_id).is_none() {
             return Err(EffectError::NodeNotFound(node_id));
@@ -212,16 +252,35 @@ impl<'a> Renderer<'a> {
         }
 
         validate_effect_params(&self.loaded_effects, effect_id, params)?;
+        validate_backdrop_config(&backdrop_config)?;
 
         let instance = build_effect_instance(
             &self.device,
             &self.loaded_effects,
             effect_id,
             params,
+            Some(backdrop_config),
             "backdrop_effect_params_buffer",
         );
 
         self.backdrop_effects.insert(node_id, instance);
+        Ok(())
+    }
+
+    pub fn update_backdrop_effect_config(
+        &mut self,
+        node_id: usize,
+        backdrop_config: effect::BackdropEffectConfig,
+    ) -> Result<(), EffectError> {
+        validate_backdrop_config(&backdrop_config)?;
+
+        let instance = self
+            .backdrop_effects
+            .get_mut(&node_id)
+            .ok_or(EffectError::NodeNotFound(node_id))?;
+        instance.backdrop_config = Some(backdrop_config);
+        instance.backdrop_texture_bind_group = None;
+        instance.backdrop_texture_id = None;
         Ok(())
     }
 
@@ -270,6 +329,22 @@ impl<'a> Renderer<'a> {
         }
     }
 
+    pub(super) fn ensure_texture_blit_pipeline(&mut self) {
+        if self.texture_blit_pipeline.is_some() {
+            return;
+        }
+
+        let composite_bind_group_layout = self
+            .composite_bgl
+            .as_ref()
+            .expect("composite bind group layout must exist before the texture blit pipeline");
+        self.texture_blit_pipeline = Some(effect::compile_texture_blit_pipeline(
+            &self.device,
+            self.config.format,
+            composite_bind_group_layout,
+        ));
+    }
+
     pub(super) fn ensure_effect_sampler(&mut self) {
         if self.effect_sampler.is_none() {
             self.effect_sampler = Some(self.device.create_sampler(&wgpu::SamplerDescriptor {
@@ -281,37 +356,6 @@ impl<'a> Renderer<'a> {
                 mipmap_filter: wgpu::FilterMode::Linear,
                 ..Default::default()
             }));
-        }
-    }
-
-    pub(super) fn ensure_backdrop_snapshot_texture(&mut self) {
-        let (width, height) = self.physical_size;
-        let needs_recreate = match &self.backdrop_snapshot_texture {
-            Some(texture) => {
-                let size = texture.size();
-                size.width != width || size.height != height
-            }
-            None => true,
-        };
-
-        if needs_recreate {
-            let texture = self.device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("backdrop_snapshot"),
-                size: wgpu::Extent3d {
-                    width,
-                    height,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: self.config.format,
-                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
-            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-            self.backdrop_snapshot_texture = Some(texture);
-            self.backdrop_snapshot_view = Some(view);
         }
     }
 
@@ -338,13 +382,14 @@ impl<'a> Renderer<'a> {
         }
 
         let uniform_bind_group_layout = self.and_pipeline.get_bind_group_layout(0);
-        let pipeline = crate::pipeline::create_stencil_keep_color_pipeline(
+        let pipeline = crate::pipeline::create_backdrop_stencil_keep_color_pipeline(
             &self.device,
             self.config.format,
             self.msaa_sample_count,
             &uniform_bind_group_layout,
             &self.shape_texture_bind_group_layout_background,
             &self.shape_texture_bind_group_layout_foreground,
+            &self.backdrop_texture_bind_group_layout,
         );
         self.backdrop_color_pipeline = Some(pipeline);
     }
@@ -355,14 +400,14 @@ impl<'a> Renderer<'a> {
         }
 
         let uniform_bind_group_layout = self.and_pipeline.get_bind_group_layout(0);
-        let pipeline = crate::pipeline::create_gradient_stencil_keep_color_pipeline(
+        let pipeline = crate::pipeline::create_backdrop_gradient_stencil_keep_color_pipeline(
             &self.device,
             self.config.format,
             self.msaa_sample_count,
             &uniform_bind_group_layout,
             &self.shape_texture_bind_group_layout_background,
             &self.shape_texture_bind_group_layout_foreground,
-            &self.gradient_bind_group_layout,
+            &self.backdrop_gradient_bind_group_layout,
         );
         self.backdrop_color_gradient_pipeline = Some(pipeline);
     }
@@ -370,7 +415,8 @@ impl<'a> Renderer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_params_expectation;
+    use super::{validate_backdrop_config, validate_params_expectation};
+    use crate::effect::{BackdropCaptureArea, BackdropEffectConfig};
 
     #[test]
     fn validate_effect_params_rejects_missing_required_params() {
@@ -394,5 +440,34 @@ mod tests {
     fn validate_effect_params_allows_non_empty_for_param_effect() {
         let result = validate_params_expectation(1, true, &[1, 2, 3, 4]);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_backdrop_config_rejects_non_positive_downsample() {
+        let result = validate_backdrop_config(&BackdropEffectConfig::new().downsample(0.0));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_backdrop_config_rejects_negative_padding() {
+        let result = validate_backdrop_config(&BackdropEffectConfig::new().padding(-1.0));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_backdrop_config_rejects_inverted_screen_rect() {
+        let result = validate_backdrop_config(
+            &BackdropEffectConfig::new()
+                .capture_area(BackdropCaptureArea::ScreenRect([(10.0, 10.0), (5.0, 15.0)])),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_backdrop_config_rejects_non_finite_screen_rect() {
+        let result = validate_backdrop_config(&BackdropEffectConfig::new().capture_area(
+            BackdropCaptureArea::ScreenRect([(0.0, 0.0), (f32::INFINITY, 15.0)]),
+        ));
+        assert!(result.is_err());
     }
 }

--- a/src/renderer/passes.rs
+++ b/src/renderer/passes.rs
@@ -619,7 +619,8 @@ fn transform_point_to_logical_screen(
         transform.col0[1] * point.0 + transform.col1[1] * point.1 + transform.col3[1];
     let homogeneous_w =
         transform.col0[3] * point.0 + transform.col1[3] * point.1 + transform.col3[3];
-    let inverse_w = 1.0 / homogeneous_w.abs().max(1e-6);
+    let clamped_w = homogeneous_w.signum() * homogeneous_w.abs().max(1e-6);
+    let inverse_w = 1.0 / clamped_w;
     (homogeneous_x * inverse_w, homogeneous_y * inverse_w)
 }
 
@@ -1696,8 +1697,9 @@ mod tests {
     use super::{
         capture_size_exceeds_budget, capture_size_exceeds_limits, inflate_logical_rect,
         logical_rect_to_physical_capture_rect, resolve_capture_region_to_viewport,
-        screen_point_to_capture_uv,
+        screen_point_to_capture_uv, transform_point_to_logical_screen,
     };
+    use crate::vertex::InstanceTransform;
 
     #[test]
     fn physical_capture_rect_preserves_requested_size_outside_viewport() {
@@ -1706,6 +1708,20 @@ mod tests {
                 .expect("capture rect should be non-empty");
 
         assert_eq!(requested_rect, (-10, 5, 40, 20));
+    }
+
+    #[test]
+    fn transform_point_to_logical_screen_preserves_negative_w_sign() {
+        let transform = InstanceTransform {
+            col0: [2.0, 0.0, 0.0, 0.0],
+            col1: [0.0, 3.0, 0.0, 0.0],
+            col2: [0.0, 0.0, 1.0, 0.0],
+            col3: [0.0, 0.0, 0.0, -2.0],
+        };
+
+        let point = transform_point_to_logical_screen((1.0, 1.0), Some(transform));
+
+        assert_eq!(point, (-1.0, -1.5));
     }
 
     #[test]

--- a/src/renderer/passes.rs
+++ b/src/renderer/passes.rs
@@ -17,21 +17,45 @@ macro_rules! with_shape_mut {
 }
 
 pub(super) struct AppliedEffectOutput {
-    pub(super) composite_bind_group: wgpu::BindGroup,
-    pub(super) primary_work_texture: wgpu::Texture,
-    pub(super) secondary_work_texture: Option<wgpu::Texture>,
+    pub(super) composite_bind_group: Option<wgpu::BindGroup>,
+    pub(super) primary_work_texture: effect::PooledTexture,
+    pub(super) secondary_work_texture: Option<effect::PooledTexture>,
+    pub(super) final_texture_is_primary: bool,
 }
 
 impl AppliedEffectOutput {
     pub(super) fn push_work_textures_into(
         self,
-        output_textures: &mut Vec<wgpu::Texture>,
-    ) -> wgpu::BindGroup {
+        output_textures: &mut Vec<effect::PooledTexture>,
+    ) -> Option<wgpu::BindGroup> {
         output_textures.push(self.primary_work_texture);
         if let Some(secondary_work_texture) = self.secondary_work_texture {
             output_textures.push(secondary_work_texture);
         }
         self.composite_bind_group
+    }
+
+    pub(super) fn final_output_view(&self) -> &wgpu::TextureView {
+        if self.final_texture_is_primary {
+            &self.primary_work_texture.color_view
+        } else {
+            &self
+                .secondary_work_texture
+                .as_ref()
+                .expect("secondary effect texture must exist when it is the final output")
+                .color_view
+        }
+    }
+
+    pub(super) fn final_output_texture_id(&self) -> u64 {
+        if self.final_texture_is_primary {
+            self.primary_work_texture.texture_id
+        } else {
+            self.secondary_work_texture
+                .as_ref()
+                .expect("secondary effect texture must exist when it is the final output")
+                .texture_id
+        }
     }
 }
 
@@ -41,6 +65,7 @@ pub(super) struct EffectPassRunConfig<'a> {
     pub(super) source_view: &'a wgpu::TextureView,
     pub(super) effect_sampler: &'a wgpu::Sampler,
     pub(super) composite_bind_group_layout: &'a wgpu::BindGroupLayout,
+    pub(super) create_composite_bind_group: bool,
     pub(super) width: u32,
     pub(super) height: u32,
     pub(super) texture_format: wgpu::TextureFormat,
@@ -50,55 +75,38 @@ pub(super) struct EffectPassRunConfig<'a> {
 pub(super) fn apply_effect_passes(
     device: &wgpu::Device,
     encoder: &mut wgpu::CommandEncoder,
+    texture_pool: &mut OffscreenTexturePool,
     config: EffectPassRunConfig<'_>,
 ) -> AppliedEffectOutput {
     let number_of_passes = config.loaded_effect.passes.len();
 
-    let effect_texture_a = device.create_texture(&wgpu::TextureDescriptor {
-        label: Some(&format!("{}_work_a", config.label_prefix)),
-        size: wgpu::Extent3d {
-            width: config.width,
-            height: config.height,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: config.texture_format,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-        view_formats: &[],
-    });
-    let effect_view_a = effect_texture_a.create_view(&wgpu::TextureViewDescriptor::default());
+    let effect_texture_a = texture_pool.acquire_color_only(
+        device,
+        config.width,
+        config.height,
+        config.texture_format,
+        1,
+    );
 
     let effect_texture_b = if number_of_passes > 1 {
-        Some(device.create_texture(&wgpu::TextureDescriptor {
-            label: Some(&format!("{}_work_b", config.label_prefix)),
-            size: wgpu::Extent3d {
-                width: config.width,
-                height: config.height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: config.texture_format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        }))
+        Some(texture_pool.acquire_color_only(
+            device,
+            config.width,
+            config.height,
+            config.texture_format,
+            1,
+        ))
     } else {
         None
     };
-    let effect_view_b = effect_texture_b
-        .as_ref()
-        .map(|texture| texture.create_view(&wgpu::TextureViewDescriptor::default()));
 
     let mut previous_input_view: &wgpu::TextureView = config.source_view;
 
     for (pass_index, effect_pass) in config.loaded_effect.passes.iter().enumerate() {
         let output_view = if pass_index % 2 == 0 {
-            &effect_view_a
+            &effect_texture_a.color_view
         } else {
-            effect_view_b.as_ref().unwrap()
+            &effect_texture_b.as_ref().unwrap().color_view
         };
 
         let input_bind_group = effect::create_texture_sample_bind_group(
@@ -140,18 +148,21 @@ pub(super) fn apply_effect_passes(
         previous_input_view = output_view;
     }
 
-    let composite_bind_group = effect::create_texture_sample_bind_group(
-        device,
-        config.composite_bind_group_layout,
-        previous_input_view,
-        config.effect_sampler,
-        Some(&format!("{}_composite_bg", config.label_prefix)),
-    );
+    let composite_bind_group = config.create_composite_bind_group.then(|| {
+        effect::create_texture_sample_bind_group(
+            device,
+            config.composite_bind_group_layout,
+            previous_input_view,
+            config.effect_sampler,
+            Some(&format!("{}_composite_bg", config.label_prefix)),
+        )
+    });
 
     AppliedEffectOutput {
         composite_bind_group,
         primary_work_texture: effect_texture_a,
         secondary_work_texture: effect_texture_b,
+        final_texture_is_primary: number_of_passes % 2 == 1,
     }
 }
 
@@ -597,6 +608,312 @@ pub(super) fn try_batch_leaf(
     false
 }
 
+fn transform_point_to_logical_screen(
+    point: (f32, f32),
+    transform: Option<InstanceTransform>,
+) -> (f32, f32) {
+    let transform = transform.unwrap_or_else(InstanceTransform::identity);
+    let homogeneous_x =
+        transform.col0[0] * point.0 + transform.col1[0] * point.1 + transform.col3[0];
+    let homogeneous_y =
+        transform.col0[1] * point.0 + transform.col1[1] * point.1 + transform.col3[1];
+    let homogeneous_w =
+        transform.col0[3] * point.0 + transform.col1[3] * point.1 + transform.col3[3];
+    let inverse_w = 1.0 / homogeneous_w.abs().max(1e-6);
+    (homogeneous_x * inverse_w, homogeneous_y * inverse_w)
+}
+
+fn transformed_bounds_to_logical_screen_rect(
+    local_bounds: [(f32, f32); 2],
+    transform: Option<InstanceTransform>,
+) -> [(f32, f32); 2] {
+    let corners = [
+        (local_bounds[0].0, local_bounds[0].1),
+        (local_bounds[1].0, local_bounds[0].1),
+        (local_bounds[1].0, local_bounds[1].1),
+        (local_bounds[0].0, local_bounds[1].1),
+    ];
+
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+
+    for corner in corners {
+        let (x, y) = transform_point_to_logical_screen(corner, transform);
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+
+    [(min_x, min_y), (max_x, max_y)]
+}
+
+fn inflate_logical_rect(logical_rect: [(f32, f32); 2], padding: f32) -> [(f32, f32); 2] {
+    if padding <= 0.0 {
+        return logical_rect;
+    }
+
+    let min_x = logical_rect[0].0.min(logical_rect[1].0) - padding;
+    let min_y = logical_rect[0].1.min(logical_rect[1].1) - padding;
+    let max_x = logical_rect[0].0.max(logical_rect[1].0) + padding;
+    let max_y = logical_rect[0].1.max(logical_rect[1].1) + padding;
+
+    [(min_x, min_y), (max_x, max_y)]
+}
+
+fn logical_rect_is_finite(logical_rect: [(f32, f32); 2]) -> bool {
+    logical_rect[0].0.is_finite()
+        && logical_rect[0].1.is_finite()
+        && logical_rect[1].0.is_finite()
+        && logical_rect[1].1.is_finite()
+}
+
+fn round_capture_coordinate(value: f32, scale_factor: f32, round_outward: bool) -> Option<i32> {
+    let scaled_value = value * scale_factor;
+    if !scaled_value.is_finite() {
+        return None;
+    }
+
+    let rounded_value = if round_outward {
+        scaled_value.ceil()
+    } else {
+        scaled_value.floor()
+    };
+    if !rounded_value.is_finite()
+        || rounded_value < i32::MIN as f32
+        || rounded_value > i32::MAX as f32
+    {
+        return None;
+    }
+
+    Some(rounded_value as i32)
+}
+
+fn logical_rect_to_physical_capture_rect(
+    logical_rect: [(f32, f32); 2],
+    scale_factor: f64,
+) -> Option<(i32, i32, u32, u32)> {
+    let scale_factor = scale_factor as f32;
+    if !scale_factor.is_finite() || scale_factor <= 0.0 || !logical_rect_is_finite(logical_rect) {
+        return None;
+    }
+
+    let min_x = logical_rect[0].0.min(logical_rect[1].0);
+    let min_y = logical_rect[0].1.min(logical_rect[1].1);
+    let max_x = logical_rect[0].0.max(logical_rect[1].0);
+    let max_y = logical_rect[0].1.max(logical_rect[1].1);
+
+    let physical_min_x = round_capture_coordinate(min_x, scale_factor, false)?;
+    let physical_min_y = round_capture_coordinate(min_y, scale_factor, false)?;
+    let physical_max_x = round_capture_coordinate(max_x, scale_factor, true)?;
+    let physical_max_y = round_capture_coordinate(max_y, scale_factor, true)?;
+
+    let width = physical_max_x.saturating_sub(physical_min_x) as u32;
+    let height = physical_max_y.saturating_sub(physical_min_y) as u32;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    Some((physical_min_x, physical_min_y, width, height))
+}
+
+fn capture_size_exceeds_limits(capture_size: (u32, u32), max_capture_dimension: u32) -> bool {
+    capture_size.0 > max_capture_dimension || capture_size.1 > max_capture_dimension
+}
+
+const MAX_BACKDROP_CAPTURE_VIEWPORT_TEXEL_MULTIPLIER: u64 = 4;
+
+fn max_backdrop_capture_texels(physical_size: (u32, u32)) -> u64 {
+    u64::from(physical_size.0)
+        .saturating_mul(u64::from(physical_size.1))
+        .saturating_mul(MAX_BACKDROP_CAPTURE_VIEWPORT_TEXEL_MULTIPLIER)
+}
+
+fn capture_size_exceeds_budget(capture_size: (u32, u32), physical_size: (u32, u32)) -> bool {
+    let capture_texels = u64::from(capture_size.0).saturating_mul(u64::from(capture_size.1));
+    capture_texels > max_backdrop_capture_texels(physical_size)
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct BackdropCaptureRegion {
+    capture_origin: (i32, i32),
+    capture_size: (u32, u32),
+    copy_source_origin: Option<(u32, u32)>,
+    copy_destination_origin: (u32, u32),
+    copy_size: (u32, u32),
+}
+
+impl BackdropCaptureRegion {
+    fn sample_uniform(self) -> crate::pipeline::BackdropSamplingUniform {
+        crate::pipeline::BackdropSamplingUniform::new(self.capture_origin, self.capture_size)
+    }
+}
+
+#[cfg(test)]
+fn screen_point_to_capture_uv(
+    sample_transform: crate::pipeline::BackdropSamplingUniform,
+    screen_point: (f32, f32),
+) -> (f32, f32) {
+    (
+        (screen_point.0 - sample_transform.capture_origin[0])
+            * sample_transform.inverse_capture_size[0],
+        (screen_point.1 - sample_transform.capture_origin[1])
+            * sample_transform.inverse_capture_size[1],
+    )
+}
+
+fn resolve_capture_region_to_viewport(
+    requested_rect: (i32, i32, u32, u32),
+    physical_size: (u32, u32),
+) -> BackdropCaptureRegion {
+    let (capture_x, capture_y, capture_width, capture_height) = requested_rect;
+    let capture_right = capture_x.saturating_add(capture_width as i32);
+    let capture_bottom = capture_y.saturating_add(capture_height as i32);
+
+    let overlap_left = capture_x.max(0);
+    let overlap_top = capture_y.max(0);
+    let overlap_right = capture_right.min(physical_size.0 as i32);
+    let overlap_bottom = capture_bottom.min(physical_size.1 as i32);
+
+    let overlap_width = overlap_right.saturating_sub(overlap_left) as u32;
+    let overlap_height = overlap_bottom.saturating_sub(overlap_top) as u32;
+    let has_overlap = overlap_width > 0 && overlap_height > 0;
+
+    BackdropCaptureRegion {
+        capture_origin: (capture_x, capture_y),
+        capture_size: (capture_width, capture_height),
+        copy_source_origin: has_overlap.then_some((overlap_left as u32, overlap_top as u32)),
+        copy_destination_origin: (
+            overlap_left.saturating_sub(capture_x) as u32,
+            overlap_top.saturating_sub(capture_y) as u32,
+        ),
+        copy_size: (overlap_width, overlap_height),
+    }
+}
+
+fn compute_backdrop_capture_region(
+    draw_command: &DrawCommand,
+    backdrop_config: effect::BackdropEffectConfig,
+    scale_factor: f64,
+    physical_size: (u32, u32),
+    max_capture_dimension: u32,
+) -> Option<BackdropCaptureRegion> {
+    let logical_rect = match backdrop_config.capture_area {
+        effect::BackdropCaptureArea::NodeBounds => transformed_bounds_to_logical_screen_rect(
+            draw_command.local_bounds(),
+            draw_command.transform(),
+        ),
+        effect::BackdropCaptureArea::FullScene => {
+            let logical_width = physical_size.0 as f32 / scale_factor as f32;
+            let logical_height = physical_size.1 as f32 / scale_factor as f32;
+            [(0.0, 0.0), (logical_width, logical_height)]
+        }
+        effect::BackdropCaptureArea::ScreenRect(rect) => rect,
+    };
+
+    let logical_rect = inflate_logical_rect(logical_rect, backdrop_config.padding);
+
+    logical_rect_to_physical_capture_rect(logical_rect, scale_factor).and_then(|requested_rect| {
+        let capture_size = (requested_rect.2, requested_rect.3);
+        if capture_size_exceeds_limits(capture_size, max_capture_dimension) {
+            warn!(
+                requested_width = capture_size.0,
+                requested_height = capture_size.1,
+                max_capture_dimension,
+                "Skipping backdrop capture that exceeds supported texture dimensions"
+            );
+            return None;
+        }
+
+        if capture_size_exceeds_budget(capture_size, physical_size) {
+            warn!(
+                requested_width = capture_size.0,
+                requested_height = capture_size.1,
+                requested_texels =
+                    u64::from(capture_size.0).saturating_mul(u64::from(capture_size.1)),
+                max_capture_texels = max_backdrop_capture_texels(physical_size),
+                viewport_width = physical_size.0,
+                viewport_height = physical_size.1,
+                "Skipping backdrop capture that exceeds the per-viewport texel budget"
+            );
+            return None;
+        }
+
+        Some(resolve_capture_region_to_viewport(
+            requested_rect,
+            physical_size,
+        ))
+    })
+}
+
+fn compute_downsampled_dimensions(capture_size: (u32, u32), downsample: f32) -> (u32, u32) {
+    (
+        ((capture_size.0 as f32) * downsample).ceil().max(1.0) as u32,
+        ((capture_size.1 as f32) * downsample).ceil().max(1.0) as u32,
+    )
+}
+
+fn clear_texture_to_transparent(
+    encoder: &mut wgpu::CommandEncoder,
+    output_view: &wgpu::TextureView,
+    label: &str,
+) {
+    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some(label),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: output_view,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn blit_texture_to_texture(
+    device: &wgpu::Device,
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::RenderPipeline,
+    bind_group_layout: &wgpu::BindGroupLayout,
+    input_view: &wgpu::TextureView,
+    output_view: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+    label: &str,
+) {
+    let bind_group = effect::create_texture_sample_bind_group(
+        device,
+        bind_group_layout,
+        input_view,
+        sampler,
+        Some(label),
+    );
+
+    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some(label),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: output_view,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+    });
+    render_pass.set_pipeline(pipeline);
+    render_pass.set_bind_group(0, &bind_group, &[]);
+    render_pass.draw(0..3, 0..1);
+}
+
 /// Unified rendering function for all paths: main scene, effect subtrees,
 /// and behind-group rendering. Processes a flat event list from
 /// `plan_traversal_in_place`, breaking render passes at backdrop effect
@@ -618,7 +935,7 @@ pub(super) fn render_segments(
     events: &[TraversalEvent],
     effect_results: &HashMap<usize, wgpu::BindGroup>,
     group_effects: &HashMap<usize, EffectInstance>,
-    backdrop_effects: &HashMap<usize, EffectInstance>,
+    backdrop_effects: &mut HashMap<usize, EffectInstance>,
     color_view: &wgpu::TextureView,
     color_resolve_target: Option<&wgpu::TextureView>,
     depth_stencil_view: &wgpu::TextureView,
@@ -626,9 +943,11 @@ pub(super) fn render_segments(
     clear_first: bool,
     pipelines: &crate::renderer::types::Pipelines,
     buffers: &crate::renderer::types::Buffers,
+    gradient_cache: &mut crate::util::GradientCache,
+    texture_pool: &mut OffscreenTexturePool,
     composite_pipeline: Option<&wgpu::RenderPipeline>,
     backdrop_ctx: Option<&crate::renderer::types::BackdropContext>,
-    backdrop_work_textures: &mut Vec<wgpu::Texture>,
+    backdrop_work_textures: &mut Vec<effect::PooledTexture>,
     stencil_stack: &mut Vec<u32>,
     scissor_stack: &mut Vec<(u32, u32, u32, u32)>,
     clip_kind_stack: &mut Vec<ClipKind>,
@@ -654,10 +973,10 @@ pub(super) fn render_segments(
         // --- Scan for the next backdrop boundary ---
         let mut segment_end = events.len();
         let mut backdrop_node_id: Option<usize> = None;
-        if let Some(bctx) = backdrop_ctx {
+        if backdrop_ctx.is_some() {
             for (idx, event) in events.iter().enumerate().skip(event_idx) {
                 if let TraversalEvent::Pre(node_id) = event {
-                    if bctx.backdrop_effects.contains_key(node_id) {
+                    if backdrop_effects.contains_key(node_id) {
                         segment_end = idx;
                         backdrop_node_id = Some(*node_id);
                         break;
@@ -995,49 +1314,186 @@ pub(super) fn render_segments(
                 );
             }
 
-            // Copy current framebuffer to the backdrop snapshot texture.
-            let copy_src =
-                copy_source_texture.expect("copy_source_texture required for backdrop effects");
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: copy_src,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: bctx.backdrop_snapshot_texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width,
-                    height,
-                    depth_or_array_layers: 1,
-                },
-            );
+            let mut solid_backdrop_bind_group: Option<wgpu::BindGroup> = None;
+            let mut gradient_backdrop_bind_group: Option<wgpu::BindGroup> = None;
 
-            // Apply the backdrop effect (blur etc.) via ping-pong passes.
-            let effect_instance = bctx.backdrop_effects.get(&backdrop_node_id).unwrap();
-            let loaded_effect = bctx.loaded_effects.get(&effect_instance.effect_id).unwrap();
-            let effect_output = apply_effect_passes(
-                bctx.device,
-                encoder,
-                EffectPassRunConfig {
-                    loaded_effect,
-                    params_bind_group: effect_instance.params_bind_group.as_ref(),
-                    source_view: bctx.backdrop_snapshot_view,
-                    effect_sampler: bctx.effect_sampler,
-                    composite_bind_group_layout: bctx.composite_bgl,
-                    width,
-                    height,
-                    texture_format: bctx.config_format,
-                    label_prefix: "backdrop_effect",
-                },
-            );
-            let backdrop_composite_bind_group =
-                effect_output.push_work_textures_into(backdrop_work_textures);
+            if let Some(draw_command) = draw_tree.get_mut(backdrop_node_id) {
+                let effect_instance = backdrop_effects
+                    .get_mut(&backdrop_node_id)
+                    .expect("backdrop node must have an attached effect instance");
+                let backdrop_config = effect_instance.backdrop_config.unwrap_or_default();
+
+                if let Some(capture_region) = compute_backdrop_capture_region(
+                    draw_command,
+                    backdrop_config,
+                    scale_factor,
+                    physical_size,
+                    bctx.max_texture_dimension_2d,
+                ) {
+                    let backdrop_sampling_uniform = capture_region.sample_uniform();
+                    let (capture_width, capture_height) = capture_region.capture_size;
+                    let copy_source_texture = copy_source_texture
+                        .expect("copy_source_texture required for backdrop effects");
+                    let backdrop_capture_texture = texture_pool.acquire_color_only(
+                        bctx.device,
+                        capture_width,
+                        capture_height,
+                        bctx.config_format,
+                        1,
+                    );
+                    if capture_region.copy_size != capture_region.capture_size {
+                        clear_texture_to_transparent(
+                            encoder,
+                            &backdrop_capture_texture.color_view,
+                            "backdrop_capture_clear",
+                        );
+                    }
+                    if let Some((copy_source_x, copy_source_y)) = capture_region.copy_source_origin
+                    {
+                        encoder.copy_texture_to_texture(
+                            wgpu::TexelCopyTextureInfo {
+                                texture: copy_source_texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d {
+                                    x: copy_source_x,
+                                    y: copy_source_y,
+                                    z: 0,
+                                },
+                                aspect: wgpu::TextureAspect::All,
+                            },
+                            wgpu::TexelCopyTextureInfo {
+                                texture: &backdrop_capture_texture.color_texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d {
+                                    x: capture_region.copy_destination_origin.0,
+                                    y: capture_region.copy_destination_origin.1,
+                                    z: 0,
+                                },
+                                aspect: wgpu::TextureAspect::All,
+                            },
+                            wgpu::Extent3d {
+                                width: capture_region.copy_size.0,
+                                height: capture_region.copy_size.1,
+                                depth_or_array_layers: 1,
+                            },
+                        );
+                    }
+
+                    let effect_input_size = compute_downsampled_dimensions(
+                        (capture_width, capture_height),
+                        backdrop_config.downsample,
+                    );
+                    let mut downsampled_capture_texture: Option<effect::PooledTexture> = None;
+
+                    if effect_input_size != (capture_width, capture_height) {
+                        let downsampled_capture_target = texture_pool.acquire_color_only(
+                            bctx.device,
+                            effect_input_size.0,
+                            effect_input_size.1,
+                            bctx.config_format,
+                            1,
+                        );
+                        blit_texture_to_texture(
+                            bctx.device,
+                            encoder,
+                            bctx.texture_blit_pipeline,
+                            bctx.composite_bgl,
+                            &backdrop_capture_texture.color_view,
+                            &downsampled_capture_target.color_view,
+                            bctx.effect_sampler,
+                            "backdrop_capture_downsample",
+                        );
+                        downsampled_capture_texture = Some(downsampled_capture_target);
+                    }
+
+                    let loaded_effect = bctx
+                        .loaded_effects
+                        .get(&effect_instance.effect_id)
+                        .expect("loaded backdrop effect must exist");
+                    let effect_output = apply_effect_passes(
+                        bctx.device,
+                        encoder,
+                        texture_pool,
+                        EffectPassRunConfig {
+                            loaded_effect,
+                            params_bind_group: effect_instance.params_bind_group.as_ref(),
+                            source_view: downsampled_capture_texture
+                                .as_ref()
+                                .map(|texture| &texture.color_view)
+                                .unwrap_or(&backdrop_capture_texture.color_view),
+                            effect_sampler: bctx.effect_sampler,
+                            composite_bind_group_layout: bctx.composite_bgl,
+                            create_composite_bind_group: false,
+                            width: effect_input_size.0,
+                            height: effect_input_size.1,
+                            texture_format: bctx.config_format,
+                            label_prefix: "backdrop_effect",
+                        },
+                    );
+
+                    let uses_gradient_backdrop = draw_command.has_gradient_fill();
+                    if let DrawCommand::CachedShape(cached_shape) = draw_command {
+                        if uses_gradient_backdrop {
+                            let gradient_backdrop_material_params_buffer = cached_shape
+                                .prepare_gradient_backdrop_material_params_buffer(
+                                    bctx.device,
+                                    bctx.queue,
+                                    backdrop_sampling_uniform,
+                                )
+                                .expect(
+                                    "gradient backdrop shapes must prepare a backdrop material params buffer",
+                                );
+                            let backdrop_view = effect_output.final_output_view();
+                            gradient_backdrop_bind_group = cached_shape
+                                .prepare_backdrop_gradient_bind_group(
+                                    gradient_cache,
+                                    bctx.device,
+                                    bctx.queue,
+                                    bctx.backdrop_gradient_bind_group_layout,
+                                    &gradient_backdrop_material_params_buffer,
+                                    bctx.gradient_ramp_sampler,
+                                    effect_output.final_output_texture_id(),
+                                    backdrop_view,
+                                    bctx.effect_sampler,
+                                )
+                                .cloned();
+                        } else {
+                            let solid_backdrop_material_params_buffer =
+                                effect::prepare_solid_backdrop_material_params_buffer(
+                                    bctx.device,
+                                    bctx.queue,
+                                    &mut effect_instance.backdrop_material_params_buffer,
+                                    backdrop_sampling_uniform,
+                                );
+
+                            if effect_instance.backdrop_texture_id
+                                != Some(effect_output.final_output_texture_id())
+                            {
+                                effect_instance.backdrop_texture_bind_group =
+                                    Some(effect::create_backdrop_texture_sample_bind_group(
+                                        bctx.device,
+                                        bctx.backdrop_texture_bind_group_layout,
+                                        &solid_backdrop_material_params_buffer,
+                                        effect_output.final_output_view(),
+                                        bctx.effect_sampler,
+                                        Some("backdrop_shape_background_bind_group"),
+                                    ));
+                                effect_instance.backdrop_texture_id =
+                                    Some(effect_output.final_output_texture_id());
+                            }
+
+                            solid_backdrop_bind_group =
+                                effect_instance.backdrop_texture_bind_group.clone();
+                        }
+                    }
+
+                    backdrop_work_textures.push(backdrop_capture_texture);
+                    if let Some(downsampled_capture_texture) = downsampled_capture_texture {
+                        backdrop_work_textures.push(downsampled_capture_texture);
+                    }
+                    effect_output.push_work_textures_into(backdrop_work_textures);
+                }
+            }
 
             // Begin the self-contained backdrop shape pass.
             let mut render_pass = crate::pipeline::begin_render_pass_with_load_ops(
@@ -1101,14 +1557,6 @@ pub(super) fn render_segments(
                 });
             }
 
-            // Step 2: Composite the blurred backdrop (stencil-masked fullscreen quad).
-            let composite_pipeline =
-                composite_pipeline.expect("composite_pipeline required for backdrop effects");
-            render_pass.set_pipeline(composite_pipeline);
-            render_pass.set_bind_group(0, &backdrop_composite_bind_group, &[]);
-            render_pass.set_stencil_reference(this_stencil);
-            render_pass.draw(0..3, 0..1);
-
             // Determine whether the backdrop node has children and whether those children should
             // inherit this node's stencil or the nearest ancestor stencil.
             let backdrop_is_leaf = draw_tree
@@ -1121,8 +1569,12 @@ pub(super) fn render_segments(
             // Step 3: Color draw (Equal + Keep).
             if let Some(draw_command) = draw_tree.get_mut(backdrop_node_id) {
                 let uses_gradient = draw_command.has_gradient_fill();
-                render_pass.set_pipeline(if uses_gradient {
+                let use_backdrop_gradient_pipeline =
+                    uses_gradient && gradient_backdrop_bind_group.is_some();
+                render_pass.set_pipeline(if use_backdrop_gradient_pipeline {
                     bctx.backdrop_color_gradient_pipeline
+                } else if uses_gradient {
+                    pipelines.leaf_draw_gradient_pipeline
                 } else {
                     bctx.backdrop_color_pipeline
                 });
@@ -1137,6 +1589,8 @@ pub(super) fn render_segments(
                     &*pipelines.default_shape_texture_bind_groups[1],
                     &[],
                 );
+                bound_texture_state.mark_bound(0, None);
+                bound_texture_state.mark_bound(1, None);
                 if !bind_aggregated_geometry_buffers(&mut render_pass, buffers) {
                     continue;
                 }
@@ -1150,11 +1604,24 @@ pub(super) fn render_segments(
                 });
 
                 if uses_gradient {
-                    let gradient_bg = draw_tree
-                        .get(backdrop_node_id)
-                        .and_then(|draw_command| draw_command.gradient_bind_group())
-                        .expect("gradient backdrop shapes must prepare a gradient bind group");
-                    render_pass.set_bind_group(3, gradient_bg.as_ref(), &[]);
+                    if let Some(gradient_backdrop_bind_group) =
+                        gradient_backdrop_bind_group.as_ref()
+                    {
+                        render_pass.set_bind_group(3, gradient_backdrop_bind_group, &[]);
+                    } else {
+                        let gradient_bind_group = draw_command
+                            .gradient_bind_group()
+                            .expect("gradient backdrop fallback should reuse the prepared gradient bind group");
+                        render_pass.set_bind_group(3, gradient_bind_group.as_ref(), &[]);
+                    }
+                } else {
+                    render_pass.set_bind_group(
+                        3,
+                        solid_backdrop_bind_group
+                            .as_ref()
+                            .unwrap_or(bctx.default_backdrop_texture_bind_group),
+                        &[],
+                    );
                 }
 
                 bind_shape_texture_layers(
@@ -1222,4 +1689,85 @@ pub(super) fn render_segments(
 
     #[cfg(feature = "render_metrics")]
     pipeline_counts_out.accumulate(&currently_set_pipeline.counts);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        capture_size_exceeds_budget, capture_size_exceeds_limits, inflate_logical_rect,
+        logical_rect_to_physical_capture_rect, resolve_capture_region_to_viewport,
+        screen_point_to_capture_uv,
+    };
+
+    #[test]
+    fn physical_capture_rect_preserves_requested_size_outside_viewport() {
+        let requested_rect =
+            logical_rect_to_physical_capture_rect([(-10.0, 5.0), (30.0, 25.0)], 1.0)
+                .expect("capture rect should be non-empty");
+
+        assert_eq!(requested_rect, (-10, 5, 40, 20));
+    }
+
+    #[test]
+    fn physical_capture_rect_rejects_non_finite_coordinates() {
+        let requested_rect =
+            logical_rect_to_physical_capture_rect([(0.0, 0.0), (f32::INFINITY, 25.0)], 1.0);
+
+        assert!(requested_rect.is_none());
+    }
+
+    #[test]
+    fn capture_size_exceeds_limits_rejects_oversized_regions() {
+        let max_capture_dimension = 4_096u32;
+
+        assert!(capture_size_exceeds_limits(
+            (max_capture_dimension + 1, 64),
+            max_capture_dimension,
+        ));
+        assert!(!capture_size_exceeds_limits(
+            (max_capture_dimension, max_capture_dimension),
+            max_capture_dimension,
+        ));
+    }
+
+    #[test]
+    fn capture_size_exceeds_budget_rejects_large_dimension_valid_regions() {
+        assert!(capture_size_exceeds_budget((1_500, 1_500), (480, 800)));
+        assert!(!capture_size_exceeds_budget((480, 800), (480, 800)));
+    }
+
+    #[test]
+    fn capture_region_offsets_visible_copy_into_transparent_texture() {
+        let region = resolve_capture_region_to_viewport((-10, 5, 40, 20), (100, 100));
+
+        assert_eq!(region.capture_origin, (-10, 5));
+        assert_eq!(region.capture_size, (40, 20));
+        assert_eq!(region.copy_source_origin, Some((0, 5)));
+        assert_eq!(region.copy_destination_origin, (10, 0));
+        assert_eq!(region.copy_size, (30, 20));
+    }
+
+    #[test]
+    fn inflate_logical_rect_expands_symmetrically() {
+        let rect = inflate_logical_rect([(10.0, 20.0), (30.0, 40.0)], 5.0);
+
+        assert_eq!(rect, [(5.0, 15.0), (35.0, 45.0)]);
+    }
+
+    #[test]
+    fn padded_capture_preserves_node_window_inside_capture() {
+        let padded_rect = inflate_logical_rect([(100.0, 100.0), (200.0, 200.0)], 20.0);
+        let requested_rect = logical_rect_to_physical_capture_rect(padded_rect, 1.0)
+            .expect("capture rect should be non-empty");
+        let capture_region = resolve_capture_region_to_viewport(requested_rect, (1_000, 1_000));
+        let sample_transform = capture_region.sample_uniform();
+
+        let top_left_uv = screen_point_to_capture_uv(sample_transform, (100.5, 100.5));
+        let bottom_right_uv = screen_point_to_capture_uv(sample_transform, (199.5, 199.5));
+
+        assert!((top_left_uv.0 - (20.5 / 140.0)).abs() < 1e-6);
+        assert!((top_left_uv.1 - (20.5 / 140.0)).abs() < 1e-6);
+        assert!((bottom_right_uv.0 - (119.5 / 140.0)).abs() < 1e-6);
+        assert!((bottom_right_uv.1 - (119.5 / 140.0)).abs() < 1e-6);
+    }
 }

--- a/src/renderer/preparation.rs
+++ b/src/renderer/preparation.rs
@@ -72,7 +72,7 @@ pub(crate) fn append_aggregated_geometry_for_shape(
         Some(existing_range)
     } else {
         let cached_shape = &cached_shape_data.cached_shape;
-        let vertex_buffers = &cached_shape.vertex_buffers;
+        let vertex_buffers = cached_shape.vertex_buffers();
         let range = append_aggregated_geometry(
             temp_vertices,
             temp_indices,

--- a/src/renderer/rect_utils.rs
+++ b/src/renderer/rect_utils.rs
@@ -229,6 +229,10 @@ mod tests {
                 params: Vec::new(),
                 params_buffer: None,
                 params_bind_group: None,
+                backdrop_config: None,
+                backdrop_material_params_buffer: None,
+                backdrop_texture_bind_group: None,
+                backdrop_texture_id: None,
             },
         );
 
@@ -247,6 +251,10 @@ mod tests {
                 params: Vec::new(),
                 params_buffer: None,
                 params_bind_group: None,
+                backdrop_config: None,
+                backdrop_material_params_buffer: None,
+                backdrop_texture_bind_group: None,
+                backdrop_texture_id: None,
             },
         );
 

--- a/src/renderer/rendering.rs
+++ b/src/renderer/rendering.rs
@@ -40,7 +40,7 @@ impl<'a> Renderer<'a> {
             self.ensure_effect_sampler();
         }
         if has_backdrop_effects {
-            self.ensure_backdrop_snapshot_texture();
+            self.ensure_texture_blit_pipeline();
             self.ensure_stencil_only_pipeline();
             self.ensure_backdrop_color_pipeline();
             self.ensure_backdrop_color_gradient_pipeline();
@@ -120,7 +120,7 @@ impl<'a> Renderer<'a> {
                     continue;
                 }
 
-                let subtree_texture = self.offscreen_texture_pool.acquire(
+                let subtree_texture = self.offscreen_texture_pool.acquire_with_depth(
                     &self.device,
                     width,
                     height,
@@ -133,7 +133,7 @@ impl<'a> Renderer<'a> {
 
                 // --- Behind-group rendering (when subtree has backdrop effects) ---
                 let behind_texture = if subtree_needs_backdrop_effects {
-                    let behind_tex = self.offscreen_texture_pool.acquire(
+                    let behind_tex = self.offscreen_texture_pool.acquire_color_only(
                         &self.device,
                         width,
                         height,
@@ -173,7 +173,7 @@ impl<'a> Renderer<'a> {
                         traversal_scratch.events(),
                         &effect_results,
                         &self.group_effects,
-                        &self.backdrop_effects,
+                        &mut self.backdrop_effects,
                         behind_color_view,
                         behind_resolve_target,
                         &behind_depth_view,
@@ -181,6 +181,8 @@ impl<'a> Renderer<'a> {
                         true,
                         &pipelines,
                         &buffers,
+                        &mut self.buffers_pool_manager.gradient_cache,
+                        &mut self.offscreen_texture_pool,
                         self.composite_pipeline.as_ref(),
                         None,
                         &mut backdrop_work_textures,
@@ -219,10 +221,11 @@ impl<'a> Renderer<'a> {
 
                 let backdrop_ctx_opt = if subtree_needs_backdrop_effects {
                     Some(crate::renderer::types::BackdropContext {
-                        backdrop_effects: &self.backdrop_effects,
                         loaded_effects: &self.loaded_effects,
                         composite_bgl: self.composite_bgl.as_ref().unwrap(),
                         effect_sampler: self.effect_sampler.as_ref().unwrap(),
+                        gradient_ramp_sampler: &self.gradient_ramp_sampler,
+                        texture_blit_pipeline: self.texture_blit_pipeline.as_ref().unwrap(),
                         stencil_only_pipeline: self.stencil_only_pipeline.as_ref().unwrap(),
                         backdrop_color_pipeline: self.backdrop_color_pipeline.as_ref().unwrap(),
                         backdrop_color_gradient_pipeline: self
@@ -230,9 +233,15 @@ impl<'a> Renderer<'a> {
                             .as_ref()
                             .unwrap(),
                         device: &self.device,
+                        queue: &self.queue,
                         config_format: self.config.format,
-                        backdrop_snapshot_texture: self.backdrop_snapshot_texture.as_ref().unwrap(),
-                        backdrop_snapshot_view: self.backdrop_snapshot_view.as_ref().unwrap(),
+                        max_texture_dimension_2d: self.device.limits().max_texture_dimension_2d,
+                        backdrop_texture_bind_group_layout: &self
+                            .backdrop_texture_bind_group_layout,
+                        default_backdrop_texture_bind_group: &self
+                            .default_backdrop_texture_bind_group,
+                        backdrop_gradient_bind_group_layout: &self
+                            .backdrop_gradient_bind_group_layout,
                     })
                 } else {
                     None
@@ -252,14 +261,19 @@ impl<'a> Renderer<'a> {
                     traversal_scratch.events(),
                     &effect_results,
                     &self.group_effects,
-                    &self.backdrop_effects,
+                    &mut self.backdrop_effects,
                     subtree_color_view,
                     subtree_resolve_target,
-                    &subtree_texture.depth_stencil_view,
+                    subtree_texture
+                        .depth_stencil_view
+                        .as_ref()
+                        .expect("subtree render targets must include a depth/stencil attachment"),
                     copy_source,
                     true,
                     &pipelines,
                     &buffers,
+                    &mut self.buffers_pool_manager.gradient_cache,
+                    &mut self.offscreen_texture_pool,
                     self.composite_pipeline.as_ref(),
                     backdrop_ctx_opt.as_ref(),
                     &mut backdrop_work_textures,
@@ -287,12 +301,14 @@ impl<'a> Renderer<'a> {
                 let effect_output = apply_effect_passes(
                     &self.device,
                     &mut encoder,
+                    &mut self.offscreen_texture_pool,
                     EffectPassRunConfig {
                         loaded_effect,
                         params_bind_group: effect_instance.params_bind_group.as_ref(),
                         source_view,
                         effect_sampler: self.effect_sampler.as_ref().unwrap(),
                         composite_bind_group_layout: self.composite_bgl.as_ref().unwrap(),
+                        create_composite_bind_group: true,
                         width,
                         height,
                         texture_format: self.config.format,
@@ -300,8 +316,9 @@ impl<'a> Renderer<'a> {
                     },
                 );
 
-                let composite_bind_group =
-                    effect_output.push_work_textures_into(&mut effect_output_textures);
+                let composite_bind_group = effect_output
+                    .push_work_textures_into(&mut effect_output_textures)
+                    .expect("group effects must create a composite bind group");
                 effect_results.insert(node_id, composite_bind_group);
                 textures_to_recycle.push(subtree_texture);
             }
@@ -331,10 +348,11 @@ impl<'a> Renderer<'a> {
 
             let backdrop_ctx_opt = if has_backdrop_effects {
                 Some(crate::renderer::types::BackdropContext {
-                    backdrop_effects: &self.backdrop_effects,
                     loaded_effects: &self.loaded_effects,
                     composite_bgl: self.composite_bgl.as_ref().unwrap(),
                     effect_sampler: self.effect_sampler.as_ref().unwrap(),
+                    gradient_ramp_sampler: &self.gradient_ramp_sampler,
+                    texture_blit_pipeline: self.texture_blit_pipeline.as_ref().unwrap(),
                     stencil_only_pipeline: self.stencil_only_pipeline.as_ref().unwrap(),
                     backdrop_color_pipeline: self.backdrop_color_pipeline.as_ref().unwrap(),
                     backdrop_color_gradient_pipeline: self
@@ -342,9 +360,12 @@ impl<'a> Renderer<'a> {
                         .as_ref()
                         .unwrap(),
                     device: &self.device,
+                    queue: &self.queue,
                     config_format: self.config.format,
-                    backdrop_snapshot_texture: self.backdrop_snapshot_texture.as_ref().unwrap(),
-                    backdrop_snapshot_view: self.backdrop_snapshot_view.as_ref().unwrap(),
+                    max_texture_dimension_2d: self.device.limits().max_texture_dimension_2d,
+                    backdrop_texture_bind_group_layout: &self.backdrop_texture_bind_group_layout,
+                    default_backdrop_texture_bind_group: &self.default_backdrop_texture_bind_group,
+                    backdrop_gradient_bind_group_layout: &self.backdrop_gradient_bind_group_layout,
                 })
             } else {
                 None
@@ -362,7 +383,7 @@ impl<'a> Renderer<'a> {
                 traversal_scratch.events(),
                 &effect_results,
                 &self.group_effects,
-                &self.backdrop_effects,
+                &mut self.backdrop_effects,
                 phase2_color_view,
                 phase2_resolve_target,
                 depth_texture_view,
@@ -370,6 +391,8 @@ impl<'a> Renderer<'a> {
                 true,
                 &pipelines,
                 &buffers,
+                &mut self.buffers_pool_manager.gradient_cache,
+                &mut self.offscreen_texture_pool,
                 self.composite_pipeline.as_ref(),
                 backdrop_ctx_opt.as_ref(),
                 &mut backdrop_work_textures,
@@ -381,17 +404,16 @@ impl<'a> Renderer<'a> {
                 #[cfg(feature = "render_metrics")]
                 &mut frame_pipeline_counts,
             );
-
-            backdrop_work_textures.clear();
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
 
         self.last_render_to_texture_view_cpu_time = render_to_texture_view_started_at.elapsed();
 
+        effect_output_textures.append(&mut backdrop_work_textures);
+        textures_to_recycle.append(&mut effect_output_textures);
         self.offscreen_texture_pool
             .recycle(&mut textures_to_recycle);
-        effect_output_textures.clear();
 
         self.draw_tree
             .iter_mut()

--- a/src/renderer/surface.rs
+++ b/src/renderer/surface.rs
@@ -108,8 +108,7 @@ impl<'a> Renderer<'a> {
             self.msaa_color_texture_view = None;
         }
 
-        self.backdrop_snapshot_texture = None;
-        self.backdrop_snapshot_view = None;
+        self.texture_blit_pipeline = None;
         self.stencil_only_pipeline = None;
         self.backdrop_color_pipeline = None;
         self.backdrop_color_gradient_pipeline = None;

--- a/src/renderer/traversal.rs
+++ b/src/renderer/traversal.rs
@@ -141,6 +141,7 @@ mod tests {
     use super::{
         compute_node_depth, plan_traversal_in_place, subtree_has_backdrop_effects, TraversalScratch,
     };
+    use crate::cache::CachedTessellation;
     use crate::effect::EffectInstance;
     use crate::renderer::types::DrawCommand;
     use crate::shape::{CachedShapeDrawData, CachedShapeHandle};
@@ -153,11 +154,13 @@ mod tests {
     fn cached_draw_data() -> CachedShapeDrawData {
         CachedShapeDrawData::new(
             CachedShapeHandle {
-                vertex_buffers: Arc::new(VertexBuffers::<CustomVertex, u16>::new()),
+                tessellation: Arc::new(CachedTessellation {
+                    vertex_buffers: Arc::new(VertexBuffers::<CustomVertex, u16>::new()),
+                    local_bounds: [(0.0, 0.0), (1.0, 1.0)],
+                    texture_mapping_size: [1.0, 1.0],
+                }),
                 is_rect: false,
                 rect_bounds: None,
-                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
-                texture_mapping_size: [1.0, 1.0],
                 geometry_id: None,
             },
             &ShapeDrawCommandOptions::new(),

--- a/src/renderer/traversal.rs
+++ b/src/renderer/traversal.rs
@@ -156,6 +156,7 @@ mod tests {
                 vertex_buffers: Arc::new(VertexBuffers::<CustomVertex, u16>::new()),
                 is_rect: false,
                 rect_bounds: None,
+                local_bounds: [(0.0, 0.0), (1.0, 1.0)],
                 texture_mapping_size: [1.0, 1.0],
                 geometry_id: None,
             },
@@ -235,6 +236,10 @@ mod tests {
                 params: Vec::new(),
                 params_buffer: None,
                 params_bind_group: None,
+                backdrop_config: None,
+                backdrop_material_params_buffer: None,
+                backdrop_texture_bind_group: None,
+                backdrop_texture_id: None,
             },
         );
 

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ahash::{HashMap, HashMapExt};
 
-use crate::effect::{self, EffectInstance, LoadedEffect};
+use crate::effect::{self, LoadedEffect};
 use crate::shape::{CachedShapeDrawData, DrawShapeCommand};
 use crate::texture_manager::TextureManager;
 use crate::util::GradientCache;
@@ -75,6 +75,13 @@ impl DrawCommand {
         match self {
             DrawCommand::CachedShape(cached_shape) => cached_shape.texture_id(layer),
             DrawCommand::ClipRect(_) => None,
+        }
+    }
+
+    pub(super) fn local_bounds(&self) -> [(f32, f32); 2] {
+        match self {
+            DrawCommand::CachedShape(cached_shape) => cached_shape.local_bounds(),
+            DrawCommand::ClipRect(clip_rect) => clip_rect.rect_bounds,
         }
     }
 
@@ -316,17 +323,21 @@ pub(super) struct Pipelines<'a> {
 /// Backdrop-specific rendering resources. Only needed when backdrop effects exist.
 /// General resources (pipelines, buffers, textures) are passed separately.
 pub(super) struct BackdropContext<'a> {
-    pub(super) backdrop_effects: &'a HashMap<usize, EffectInstance>,
     pub(super) loaded_effects: &'a HashMap<u64, LoadedEffect>,
     pub(super) composite_bgl: &'a wgpu::BindGroupLayout,
     pub(super) effect_sampler: &'a wgpu::Sampler,
+    pub(super) gradient_ramp_sampler: &'a wgpu::Sampler,
+    pub(super) texture_blit_pipeline: &'a wgpu::RenderPipeline,
     pub(super) stencil_only_pipeline: &'a wgpu::RenderPipeline,
     pub(super) backdrop_color_pipeline: &'a wgpu::RenderPipeline,
     pub(super) backdrop_color_gradient_pipeline: &'a wgpu::RenderPipeline,
     pub(super) device: &'a wgpu::Device,
+    pub(super) queue: &'a wgpu::Queue,
     pub(super) config_format: wgpu::TextureFormat,
-    pub(super) backdrop_snapshot_texture: &'a wgpu::Texture,
-    pub(super) backdrop_snapshot_view: &'a wgpu::TextureView,
+    pub(super) max_texture_dimension_2d: u32,
+    pub(super) backdrop_texture_bind_group_layout: &'a wgpu::BindGroupLayout,
+    pub(super) default_backdrop_texture_bind_group: &'a wgpu::BindGroup,
+    pub(super) backdrop_gradient_bind_group_layout: &'a wgpu::BindGroupLayout,
 }
 
 const MAX_EFFECT_RESULTS_CAPACITY: usize = 4_096;
@@ -342,7 +353,7 @@ pub(super) struct RendererScratch {
     pub(super) effect_results: HashMap<usize, wgpu::BindGroup>,
     pub(super) effect_node_ids: Vec<(usize, usize)>,
     pub(super) textures_to_recycle: Vec<effect::PooledTexture>,
-    pub(super) effect_output_textures: Vec<wgpu::Texture>,
+    pub(super) effect_output_textures: Vec<effect::PooledTexture>,
     pub(super) stencil_stack: Vec<u32>,
     pub(super) skipped_stack: Vec<usize>,
     /// Stack of intersected scissor rects (x, y, width, height) in physical pixels.
@@ -351,7 +362,7 @@ pub(super) struct RendererScratch {
     /// Parallel stack to `stencil_stack`: records which clipping strategy each
     /// non-leaf parent used so the `Post` path avoids re-evaluating eligibility.
     pub(super) clip_kind_stack: Vec<ClipKind>,
-    pub(super) backdrop_work_textures: Vec<wgpu::Texture>,
+    pub(super) backdrop_work_textures: Vec<effect::PooledTexture>,
     /// Reused across readback calls; intentionally not cleared on `begin_frame`
     /// because readback may run after render submission and reuse prior capacity.
     pub(super) readback_bytes: Vec<u8>,

--- a/src/shaders/shader.wgsl
+++ b/src/shaders/shader.wgsl
@@ -62,9 +62,8 @@ struct Uniforms {
 // Layer 1 (foreground/overlay)
 @group(2) @binding(0) var t_shape_layer1: texture_2d<f32>;
 @group(2) @binding(1) var s_shape_layer1: sampler;
-
-// Gradient resources (group 3)
-struct GradientParams {
+// Shared material resources (group 3)
+struct GradientColorParams {
     gradient_type: u32,   // 0=none, 1=linear, 2=radial, 3=conic
     spread_mode: u32,     // 0=pad, 1=repeat
     units: u32,           // 0=local (model space), 1=canvas (screen space)
@@ -83,9 +82,22 @@ struct GradientParams {
     _padding: f32,
 };
 
-@group(3) @binding(0) var<uniform> gradient_params: GradientParams;
+struct BackdropSamplingParams {
+    capture_origin: vec2<f32>,
+    inverse_capture_size: vec2<f32>,
+};
+
+struct MaterialParams {
+    gradient: GradientColorParams,
+    backdrop_sampling: BackdropSamplingParams,
+};
+
+@group(3) @binding(0) var<uniform> material_params: MaterialParams;
 @group(3) @binding(1) var t_gradient_ramp: texture_1d<f32>;
 @group(3) @binding(2) var s_gradient_ramp: sampler;
+// Specialized backdrop layer used only by backdrop color pipelines.
+@group(3) @binding(3) var t_backdrop_layer: texture_2d<f32>;
+@group(3) @binding(4) var s_backdrop_layer: sampler;
 
 fn to_linear(color: vec3<f32>) -> vec3<f32> {
     let cutoff = vec3<f32>(0.04045);
@@ -105,20 +117,20 @@ fn to_srgb(color: vec3<f32>) -> vec3<f32> {
 
 /// Computes the raw gradient parameter t for the given position.
 fn gradient_raw_t(pos: vec2<f32>) -> f32 {
-    let gtype = gradient_params.gradient_type;
+    let gtype = material_params.gradient.gradient_type;
     if gtype == 1u {
         // Linear
-        let d = gradient_params.linear_end - gradient_params.linear_start;
+        let d = material_params.gradient.linear_end - material_params.gradient.linear_start;
         let len_sq = dot(d, d);
         if len_sq < 1e-12 {
             return 0.0;
         }
-        return dot(pos - gradient_params.linear_start, d) / len_sq;
+        return dot(pos - material_params.gradient.linear_start, d) / len_sq;
     } else if gtype == 2u {
         // Radial (elliptical)
-        let diff = pos - gradient_params.radial_center;
-        let rx = gradient_params.radial_radius.x;
-        let ry = gradient_params.radial_radius.y;
+        let diff = pos - material_params.gradient.radial_center;
+        let rx = material_params.gradient.radial_radius.x;
+        let ry = material_params.gradient.radial_radius.y;
         if rx < 1e-6 || ry < 1e-6 {
             return 0.0;
         }
@@ -127,9 +139,9 @@ fn gradient_raw_t(pos: vec2<f32>) -> f32 {
         return length(vec2<f32>(nx, ny));
     } else if gtype == 3u {
         // Conic
-        let diff = pos - gradient_params.conic_center;
+        let diff = pos - material_params.gradient.conic_center;
         var angle = atan2(diff.y, diff.x); // [-pi, pi]
-        angle = angle - gradient_params.conic_start_angle;
+        angle = angle - material_params.gradient.conic_start_angle;
         // Normalize to [0, 1)
         let tau = 6.283185307179586;
         angle = angle - floor(angle / tau) * tau;
@@ -140,10 +152,10 @@ fn gradient_raw_t(pos: vec2<f32>) -> f32 {
 
 /// Applies the spread mode (pad or repeat) and maps t to the ramp UV.
 fn gradient_apply_spread(raw_t: f32) -> f32 {
-    let period_start = gradient_params.period_start;
-    let period_len = gradient_params.period_len;
-    let ramp_start = gradient_params.ramp_start;
-    let ramp_end = gradient_params.ramp_end;
+    let period_start = material_params.gradient.period_start;
+    let period_len = material_params.gradient.period_len;
+    let ramp_start = material_params.gradient.ramp_start;
+    let ramp_end = material_params.gradient.ramp_end;
 
     if period_len <= 0.0 {
         // Non-repeating: clamp to ramp domain
@@ -155,7 +167,7 @@ fn gradient_apply_spread(raw_t: f32) -> f32 {
     }
 
     // Repeating gradient: wrap into the period
-    let spread = gradient_params.spread_mode;
+    let spread = material_params.gradient.spread_mode;
     var t = raw_t;
 
     if spread == 1u {
@@ -175,17 +187,17 @@ fn gradient_apply_spread(raw_t: f32) -> f32 {
 /// Evaluates the gradient at the given model and screen positions.
 /// Returns a premultiplied linear RGBA color from the pre-baked ramp.
 fn evaluate_gradient(model_pos: vec2<f32>, screen_pos: vec2<f32>) -> vec4<f32> {
-    let gtype = gradient_params.gradient_type;
+    let gtype = material_params.gradient.gradient_type;
     if gtype == 0u {
         // No gradient — return transparent (caller uses solid fill)
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 
-    if gradient_params.is_constant != 0u {
-        return gradient_params.constant_color;
+    if material_params.gradient.is_constant != 0u {
+        return material_params.gradient.constant_color;
     }
 
-    let pos = select(screen_pos, model_pos, gradient_params.units == 0u);
+    let pos = select(screen_pos, model_pos, material_params.gradient.units == 0u);
     let raw_t = gradient_raw_t(pos);
     let uv = gradient_apply_spread(raw_t);
 
@@ -401,6 +413,65 @@ fn compute_gradient_fragment_color(
     return final_pma * coverage;
 }
 
+fn compute_fragment_color_with_backdrop(
+    fragment_position: vec4<f32>,
+    color: vec4<f32>,
+    layer0_tex_coords: vec2<f32>,
+    layer1_tex_coords: vec2<f32>,
+    coverage: f32,
+    texture_flags: f32,
+) -> vec4<f32> {
+    let fill_pma = vec4<f32>(color.rgb * color.a, color.a);
+    let backdrop_uv = (fragment_position.xy - material_params.backdrop_sampling.capture_origin)
+        * material_params.backdrop_sampling.inverse_capture_size;
+    let backdrop_pma = textureSampleLevel(t_backdrop_layer, s_backdrop_layer, backdrop_uv, 0.0);
+
+    let flags = u32(texture_flags);
+    var base_pma = fill_pma + backdrop_pma * (1.0 - fill_pma.a);
+    if ((flags & 1u) != 0u) {
+            let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, layer0_tex_coords, 0.0);
+            base_pma = layer0_pma + base_pma * (1.0 - layer0_pma.a);
+    }
+
+    var final_pma = base_pma;
+    if ((flags & 2u) != 0u) {
+            let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, layer1_tex_coords, 0.0);
+            final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
+    }
+
+    return final_pma * coverage;
+}
+
+fn compute_gradient_fragment_color_with_backdrop(
+    fragment_position: vec4<f32>,
+    layer0_tex_coords: vec2<f32>,
+    layer1_tex_coords: vec2<f32>,
+    coverage: f32,
+    texture_flags: f32,
+    model_pos: vec2<f32>,
+    screen_pos: vec2<f32>,
+) -> vec4<f32> {
+    let fill_pma = evaluate_gradient(model_pos, screen_pos);
+    let backdrop_uv = (fragment_position.xy - material_params.backdrop_sampling.capture_origin)
+        * material_params.backdrop_sampling.inverse_capture_size;
+    let backdrop_pma = textureSampleLevel(t_backdrop_layer, s_backdrop_layer, backdrop_uv, 0.0);
+
+    let flags = u32(texture_flags);
+    var base_pma = fill_pma + backdrop_pma * (1.0 - fill_pma.a);
+    if ((flags & 1u) != 0u) {
+            let layer0_pma = textureSampleLevel(t_shape_layer0, s_shape_layer0, layer0_tex_coords, 0.0);
+            base_pma = layer0_pma + base_pma * (1.0 - layer0_pma.a);
+    }
+
+    var final_pma = base_pma;
+    if ((flags & 2u) != 0u) {
+            let layer1_pma = textureSampleLevel(t_shape_layer1, s_shape_layer1, layer1_tex_coords, 0.0);
+            final_pma = layer1_pma + base_pma * (1.0 - layer1_pma.a);
+    }
+
+    return final_pma * coverage;
+}
+
 @fragment
 fn fs_main(
     @location(0) color: vec4<f32>,
@@ -477,6 +548,47 @@ fn fs_passthrough_gradient(
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
     return compute_gradient_fragment_color(
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+        model_pos,
+        screen_pos,
+    );
+}
+
+@fragment
+fn fs_backdrop_passthrough(
+    @builtin(position) fragment_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
+) -> @location(0) vec4<f32> {
+    return compute_fragment_color_with_backdrop(
+        fragment_position,
+        color,
+        layer0_tex_coords,
+        layer1_tex_coords,
+        coverage,
+        texture_flags,
+    );
+}
+
+@fragment
+fn fs_backdrop_passthrough_gradient(
+    @builtin(position) fragment_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) layer0_tex_coords: vec2<f32>,
+    @location(2) layer1_tex_coords: vec2<f32>,
+    @location(3) coverage: f32,
+    @location(4) @interpolate(flat) texture_flags: f32,
+    @location(5) model_pos: vec2<f32>,
+    @location(6) screen_pos: vec2<f32>,
+) -> @location(0) vec4<f32> {
+    return compute_gradient_fragment_color_with_backdrop(
+        fragment_position,
         layer0_tex_coords,
         layer1_tex_coords,
         coverage,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -55,6 +55,8 @@ pub struct CachedShapeHandle {
     pub(crate) is_rect: bool,
     /// The local-space bounding rect when `is_rect` is true, for scissor computation.
     pub(crate) rect_bounds: Option<[(f32, f32); 2]>,
+    /// Local-space axis-aligned bounds for the tessellated shape.
+    pub(crate) local_bounds: [(f32, f32); 2],
     /// Width and height of the local-space bounds used to normalize texture coordinates.
     pub(crate) texture_mapping_size: [f32; 2],
     pub(crate) geometry_id: Option<u64>,
@@ -88,13 +90,13 @@ impl CachedShapeHandle {
             TessellatedGeometry::Owned(vertex_buffers) => Arc::new(vertex_buffers),
             TessellatedGeometry::Shared(vertex_buffers) => vertex_buffers,
         };
-        let texture_mapping_size = rect_bounds
-            .map(rect_size)
-            .unwrap_or_else(|| compute_texture_mapping_size(&vertices));
+        let local_bounds = rect_bounds.unwrap_or_else(|| compute_vertex_bounds(&vertices));
+        let texture_mapping_size = rect_size(local_bounds);
         Self {
             vertex_buffers: vertices,
             is_rect,
             rect_bounds,
+            local_bounds,
             texture_mapping_size,
             geometry_id,
         }
@@ -108,9 +110,9 @@ fn rect_size(rect_bounds: [(f32, f32); 2]) -> [f32; 2] {
     ]
 }
 
-fn compute_texture_mapping_size(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [f32; 2] {
+fn compute_vertex_bounds(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [(f32, f32); 2] {
     if vertex_buffers.vertices.is_empty() {
-        return [1.0, 1.0];
+        return [(0.0, 0.0), (1.0, 1.0)];
     }
 
     let mut min_x = f32::INFINITY;
@@ -135,7 +137,7 @@ fn compute_texture_mapping_size(vertex_buffers: &VertexBuffers<CustomVertex, u16
         }
     }
 
-    [(max_x - min_x).max(1e-6), (max_y - min_y).max(1e-6)]
+    [(min_x, min_y), (max_x, max_y)]
 }
 
 pub(crate) enum TessellatedGeometry {
@@ -1226,6 +1228,12 @@ pub(crate) struct CachedShapeDrawData {
     pub(crate) fill: Option<Fill>,
     /// Cached gradient bind group, refreshed when the fill or gradient layout changes.
     pub(crate) gradient_bind_group: Option<Arc<wgpu::BindGroup>>,
+    /// Persistent uniform buffer for backdrop material parameters.
+    pub(crate) backdrop_material_params_buffer: Option<wgpu::Buffer>,
+    /// Cached gradient+backdrop bind group reused while the captured output texture is stable.
+    pub(crate) backdrop_gradient_bind_group: Option<wgpu::BindGroup>,
+    /// Stable id of the pooled texture referenced by `backdrop_gradient_bind_group`.
+    pub(crate) backdrop_gradient_texture_id: Option<u64>,
     /// Whether this node is a leaf in the draw tree (no children).
     pub(crate) is_leaf: bool,
     /// When `false`, skip stencil increment/decrement for this parent
@@ -1257,6 +1265,9 @@ impl CachedShapeDrawData {
             // Set during render traversal
             stencil_ref: None,
             gradient_bind_group: None,
+            backdrop_material_params_buffer: None,
+            backdrop_gradient_bind_group: None,
+            backdrop_gradient_texture_id: None,
             is_leaf: true,
         }
     }
@@ -1281,6 +1292,72 @@ impl CachedShapeDrawData {
             )),
             _ => None,
         };
+    }
+
+    pub fn prepare_gradient_backdrop_material_params_buffer(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        backdrop_sampling_uniform: crate::pipeline::BackdropSamplingUniform,
+    ) -> Option<wgpu::Buffer> {
+        let params = {
+            let gradient = match self.fill.as_ref() {
+                Some(Fill::Gradient(gradient)) => gradient,
+                _ => return None,
+            };
+
+            crate::gradient::gpu::GpuMaterialParams::from_gradient_data(&gradient.data)
+                .with_backdrop_sampling(backdrop_sampling_uniform)
+        };
+
+        if let Some(existing_buffer) = self.backdrop_material_params_buffer.as_ref() {
+            queue.write_buffer(existing_buffer, 0, bytemuck::bytes_of(&params));
+        } else {
+            self.backdrop_material_params_buffer = Some(crate::pipeline::create_buffer_init(
+                device,
+                Some("gradient_backdrop_material_params_buffer"),
+                bytemuck::bytes_of(&params),
+                wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            ));
+        }
+
+        self.backdrop_material_params_buffer.clone()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare_backdrop_gradient_bind_group(
+        &mut self,
+        gradient_cache: &mut GradientCache,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        layout: &wgpu::BindGroupLayout,
+        material_params_buffer: &wgpu::Buffer,
+        gradient_sampler: &wgpu::Sampler,
+        backdrop_texture_id: u64,
+        backdrop_view: &wgpu::TextureView,
+        backdrop_sampler: &wgpu::Sampler,
+    ) -> Option<&wgpu::BindGroup> {
+        if self.backdrop_gradient_texture_id != Some(backdrop_texture_id) {
+            let gradient = match self.fill.as_mut() {
+                Some(Fill::Gradient(gradient)) => gradient,
+                _ => return None,
+            };
+
+            self.backdrop_gradient_bind_group =
+                Some(gradient_cache.create_backdrop_gradient_bind_group(
+                    &mut gradient.data,
+                    device,
+                    queue,
+                    layout,
+                    material_params_buffer,
+                    gradient_sampler,
+                    backdrop_view,
+                    backdrop_sampler,
+                ));
+            self.backdrop_gradient_texture_id = Some(backdrop_texture_id);
+        }
+
+        self.backdrop_gradient_bind_group.as_ref()
     }
 }
 
@@ -1612,6 +1689,7 @@ pub(crate) trait DrawShapeCommand {
     fn instance_index(&self) -> Option<usize>;
     fn transform(&self) -> Option<InstanceTransform>;
     fn texture_id(&self, layer: usize) -> Option<u64>;
+    fn local_bounds(&self) -> [(f32, f32); 2];
     fn instance_color_override(&self) -> Option<[f32; 4]>;
     fn has_gradient_fill(&self) -> bool;
     fn gradient_bind_group(&self) -> Option<&std::sync::Arc<wgpu::BindGroup>>;
@@ -1654,6 +1732,11 @@ impl DrawShapeCommand for CachedShapeDrawData {
     #[inline]
     fn texture_id(&self, layer: usize) -> Option<u64> {
         self.texture_ids.get(layer).copied().unwrap_or(None)
+    }
+
+    #[inline]
+    fn local_bounds(&self) -> [(f32, f32); 2] {
+        self.cached_shape.local_bounds
     }
 
     #[inline]

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -34,6 +34,7 @@
 //!     .build();
 //! ```
 
+use crate::cache::CachedTessellation;
 use crate::gradient::types::Fill;
 use crate::util::{GradientCache, PoolManager};
 use crate::vertex::{CustomVertex, InstanceTransform};
@@ -49,16 +50,12 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct CachedShapeHandle {
-    pub vertex_buffers: Arc<VertexBuffers<CustomVertex, u16>>,
+    pub(crate) tessellation: Arc<CachedTessellation>,
     /// Whether the original shape was an axis-aligned rectangle. Used to enable scissor-based
     /// clipping instead of stencil for rect parents.
     pub(crate) is_rect: bool,
     /// The local-space bounding rect when `is_rect` is true, for scissor computation.
     pub(crate) rect_bounds: Option<[(f32, f32); 2]>,
-    /// Local-space axis-aligned bounds for the tessellated shape.
-    pub(crate) local_bounds: [(f32, f32); 2],
-    /// Width and height of the local-space bounds used to normalize texture coordinates.
-    pub(crate) texture_mapping_size: [f32; 2],
     pub(crate) geometry_id: Option<u64>,
 }
 
@@ -86,20 +83,28 @@ impl CachedShapeHandle {
             Shape::Rect(r) => (true, Some(r.rect)),
             _ => (false, None),
         };
-        let vertices = match shape.tessellate(tessellator, pool, geometry_id) {
-            TessellatedGeometry::Owned(vertex_buffers) => Arc::new(vertex_buffers),
-            TessellatedGeometry::Shared(vertex_buffers) => vertex_buffers,
-        };
-        let local_bounds = rect_bounds.unwrap_or_else(|| compute_vertex_bounds(&vertices));
-        let texture_mapping_size = rect_size(local_bounds);
+        let tessellation = shape.tessellate(tessellator, pool, geometry_id);
         Self {
-            vertex_buffers: vertices,
+            tessellation,
             is_rect,
             rect_bounds,
-            local_bounds,
-            texture_mapping_size,
             geometry_id,
         }
+    }
+
+    #[inline]
+    pub(crate) fn vertex_buffers(&self) -> &Arc<VertexBuffers<CustomVertex, u16>> {
+        &self.tessellation.vertex_buffers
+    }
+
+    #[inline]
+    pub(crate) fn local_bounds(&self) -> [(f32, f32); 2] {
+        self.tessellation.local_bounds
+    }
+
+    #[inline]
+    pub(crate) fn texture_mapping_size(&self) -> [f32; 2] {
+        self.tessellation.texture_mapping_size
     }
 }
 
@@ -110,8 +115,8 @@ fn rect_size(rect_bounds: [(f32, f32); 2]) -> [f32; 2] {
     ]
 }
 
-fn compute_vertex_bounds(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [(f32, f32); 2] {
-    if vertex_buffers.vertices.is_empty() {
+fn compute_vertex_bounds(vertices: &[CustomVertex]) -> [(f32, f32); 2] {
+    if vertices.is_empty() {
         return [(0.0, 0.0), (1.0, 1.0)];
     }
 
@@ -120,7 +125,7 @@ fn compute_vertex_bounds(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [
     let mut max_x = f32::NEG_INFINITY;
     let mut max_y = f32::NEG_INFINITY;
 
-    for vertex in &vertex_buffers.vertices {
+    for vertex in vertices {
         let x = vertex.position[0];
         let y = vertex.position[1];
         if x < min_x {
@@ -138,30 +143,6 @@ fn compute_vertex_bounds(vertex_buffers: &VertexBuffers<CustomVertex, u16>) -> [
     }
 
     [(min_x, min_y), (max_x, max_y)]
-}
-
-pub(crate) enum TessellatedGeometry {
-    /// When the cache key is not provided, or the geometry is a simple rect
-    Owned(VertexBuffers<CustomVertex, u16>),
-    Shared(Arc<VertexBuffers<CustomVertex, u16>>),
-}
-
-impl TessellatedGeometry {
-    #[cfg(test)]
-    pub(crate) fn vertices(&self) -> &[CustomVertex] {
-        match self {
-            Self::Owned(vertex_buffers) => &vertex_buffers.vertices,
-            Self::Shared(vertex_buffers) => &vertex_buffers.vertices,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn indices(&self) -> &[u16] {
-        match self {
-            Self::Owned(vertex_buffers) => &vertex_buffers.indices,
-            Self::Shared(vertex_buffers) => &vertex_buffers.indices,
-        }
-    }
 }
 
 /// Represents a graphical shape, which can be either a custom path or a simple rectangle.
@@ -278,18 +259,18 @@ impl Shape {
         tessellator: &mut FillTessellator,
         buffers_pool: &mut PoolManager,
         tesselation_cache_key: Option<u64>,
-    ) -> TessellatedGeometry {
+    ) -> Arc<CachedTessellation> {
         match &self {
             Shape::Path(path_shape) => {
                 path_shape.tessellate(tessellator, buffers_pool, tesselation_cache_key)
             }
             Shape::Rect(rect_shape) => {
                 if let Some(cache_key) = tesselation_cache_key {
-                    if let Some(cached_vertex_buffers) = buffers_pool
+                    if let Some(cached_tessellation) = buffers_pool
                         .tessellation_cache
                         .get_vertex_buffers(&cache_key)
                     {
-                        return TessellatedGeometry::Shared(cached_vertex_buffers);
+                        return cached_tessellation;
                     }
                 }
 
@@ -331,6 +312,7 @@ impl Shape {
                     },
                 ];
                 let indices = [0u16, 1, 2, 0, 2, 3];
+                let local_bounds = rect_shape.rect;
 
                 let mut vertex_buffers = buffers_pool.lyon_vertex_buffers_pool.get_vertex_buffers();
 
@@ -344,15 +326,19 @@ impl Shape {
                     &mut buffers_pool.aa_fringe_scratch,
                 );
 
+                let tessellation = Arc::new(CachedTessellation {
+                    vertex_buffers: Arc::new(vertex_buffers),
+                    local_bounds,
+                    texture_mapping_size: rect_size(local_bounds),
+                });
+
                 if let Some(tesselation_cache_key) = tesselation_cache_key {
-                    let arc_buffers = Arc::new(vertex_buffers);
                     buffers_pool
                         .tessellation_cache
-                        .insert_vertex_buffers(tesselation_cache_key, Arc::clone(&arc_buffers));
-                    TessellatedGeometry::Shared(arc_buffers)
-                } else {
-                    TessellatedGeometry::Owned(vertex_buffers)
+                        .insert_vertex_buffers(tesselation_cache_key, Arc::clone(&tessellation));
                 }
+
+                tessellation
             }
         }
     }
@@ -991,19 +977,19 @@ impl PathShape {
         tessellator: &mut FillTessellator,
         buffers_pool: &mut PoolManager,
         tesselation_cache_key: Option<u64>,
-    ) -> TessellatedGeometry {
+    ) -> Arc<CachedTessellation> {
         if let Some(cache_key) = tesselation_cache_key {
-            if let Some(cached_vertex_buffers) = buffers_pool
+            if let Some(cached_tessellation) = buffers_pool
                 .tessellation_cache
                 .get_vertex_buffers(&cache_key)
             {
-                return TessellatedGeometry::Shared(cached_vertex_buffers);
+                return cached_tessellation;
             }
         }
 
         let mut buffers: VertexBuffers<CustomVertex, u16> =
             buffers_pool.lyon_vertex_buffers_pool.get_vertex_buffers();
-        self.tessellate_into_buffers(
+        let local_bounds = self.tessellate_into_buffers(
             &mut buffers,
             tessellator,
             &mut buffers_pool.aa_fringe_scratch,
@@ -1015,15 +1001,19 @@ impl PathShape {
             buffers.indices.push(0);
         }
 
+        let tessellation = Arc::new(CachedTessellation {
+            vertex_buffers: Arc::new(buffers),
+            local_bounds,
+            texture_mapping_size: rect_size(local_bounds),
+        });
+
         if let Some(cache_key) = tesselation_cache_key {
-            let shared_vertex_buffers = Arc::new(buffers);
             buffers_pool
                 .tessellation_cache
-                .insert_vertex_buffers(cache_key, shared_vertex_buffers.clone());
-            TessellatedGeometry::Shared(shared_vertex_buffers)
-        } else {
-            TessellatedGeometry::Owned(buffers)
+                .insert_vertex_buffers(cache_key, Arc::clone(&tessellation));
         }
+
+        tessellation
     }
 
     fn tessellate_into_buffers(
@@ -1031,7 +1021,7 @@ impl PathShape {
         buffers: &mut VertexBuffers<CustomVertex, u16>,
         tessellator: &mut FillTessellator,
         aa_fringe_scratch: &mut AaFringeScratch,
-    ) {
+    ) -> [(f32, f32); 2] {
         let options = FillOptions::default();
 
         let vertex_converter = VertexConverter::new();
@@ -1044,34 +1034,15 @@ impl PathShape {
             )
             .unwrap();
 
+        let local_bounds = compute_vertex_bounds(&buffers.vertices);
+
         // Generate UVs for the tessellated path using its axis-aligned bounding box in local space
         if !buffers.vertices.is_empty() {
-            // Compute AABB of positions before offset translation
-            let mut min_x = f32::INFINITY;
-            let mut min_y = f32::INFINITY;
-            let mut max_x = f32::NEG_INFINITY;
-            let mut max_y = f32::NEG_INFINITY;
-            for v in buffers.vertices.iter() {
-                let x = v.position[0];
-                let y = v.position[1];
-                if x < min_x {
-                    min_x = x;
-                }
-                if y < min_y {
-                    min_y = y;
-                }
-                if x > max_x {
-                    max_x = x;
-                }
-                if y > max_y {
-                    max_y = y;
-                }
-            }
-            let w = (max_x - min_x).max(1e-6);
-            let h = (max_y - min_y).max(1e-6);
+            let w = (local_bounds[1].0 - local_bounds[0].0).max(1e-6);
+            let h = (local_bounds[1].1 - local_bounds[0].1).max(1e-6);
             for v in buffers.vertices.iter_mut() {
-                let u = (v.position[0] - min_x) / w;
-                let vcoord = (v.position[1] - min_y) / h;
+                let u = (v.position[0] - local_bounds[0].0) / w;
+                let vcoord = (v.position[1] - local_bounds[0].1) / h;
                 v.tex_coords = [u, vcoord];
             }
         }
@@ -1083,6 +1054,8 @@ impl PathShape {
             &mut buffers.indices,
             aa_fringe_scratch,
         );
+
+        local_bounds
     }
 }
 
@@ -1736,7 +1709,7 @@ impl DrawShapeCommand for CachedShapeDrawData {
 
     #[inline]
     fn local_bounds(&self) -> [(f32, f32); 2] {
-        self.cached_shape.local_bounds
+        self.cached_shape.local_bounds()
     }
 
     #[inline]
@@ -1833,11 +1806,12 @@ mod tests {
         let tessellated_geometry =
             Shape::Rect(rect_shape).tessellate(&mut tessellator, &mut pool_manager, None);
 
-        assert_eq!(tessellated_geometry.vertices().len(), 8);
-        assert_eq!(tessellated_geometry.indices().len(), 30);
+        assert_eq!(tessellated_geometry.vertex_buffers.vertices.len(), 8);
+        assert_eq!(tessellated_geometry.vertex_buffers.indices.len(), 30);
 
         let fill_vertex_count = tessellated_geometry
-            .vertices()
+            .vertex_buffers
+            .vertices
             .iter()
             .filter(|vertex| vertex.coverage == 1.0)
             .count();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,7 @@
 use crate::cache::Cache;
-use crate::gradient::gpu::{create_default_ramp_texture, create_ramp_texture, GpuGradientParams};
+use crate::gradient::gpu::{
+    create_default_ramp_texture, create_ramp_texture, GpuGradientColorParams, GpuMaterialParams,
+};
 use crate::gradient::sampling::bake_gradient_ramp;
 use crate::gradient::types::{GradientData, GradientRamp, GradientRampCacheKey};
 use crate::shape::AaFringeScratch;
@@ -42,12 +44,12 @@ pub struct LyonVertexBuffersPool {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct GradientBindGroupCacheKey {
     layout_epoch: u64,
-    params: GpuGradientParamsKey,
+    params: GpuGradientColorParamsKey,
     ramp_key: GradientRampCacheKey,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct GpuGradientParamsKey {
+struct GpuGradientColorParamsKey {
     gradient_type: u32,
     spread_mode: u32,
     units: u32,
@@ -65,8 +67,8 @@ struct GpuGradientParamsKey {
     ramp_end: u32,
 }
 
-impl GpuGradientParamsKey {
-    fn from_params(params: GpuGradientParams) -> Self {
+impl GpuGradientColorParamsKey {
+    fn from_params(params: GpuGradientColorParams) -> Self {
         Self {
             gradient_type: params.gradient_type,
             spread_mode: params.spread_mode,
@@ -194,10 +196,10 @@ impl GradientCache {
         sampler: &wgpu::Sampler,
         layout_epoch: u64,
     ) -> Arc<wgpu::BindGroup> {
-        let params = GpuGradientParams::from_gradient_data(gradient_data);
+        let material_params = GpuMaterialParams::from_gradient_data(gradient_data);
         let cache_key = GradientBindGroupCacheKey {
             layout_epoch,
-            params: GpuGradientParamsKey::from_params(params),
+            params: GpuGradientColorParamsKey::from_params(material_params.gradient),
             ramp_key: gradient_data.ramp_cache_key.clone(),
         };
 
@@ -213,8 +215,8 @@ impl GradientCache {
 
         let params_buffer = crate::pipeline::create_buffer_init(
             device,
-            Some("Gradient Params Buffer"),
-            bytemuck::cast_slice(&[params]),
+            Some("Material Params Buffer"),
+            bytemuck::cast_slice(&[material_params]),
             wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         );
 
@@ -239,6 +241,52 @@ impl GradientCache {
 
         self.bind_groups.put(cache_key, bind_group.clone());
         bind_group
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn create_backdrop_gradient_bind_group(
+        &mut self,
+        gradient_data: &mut GradientData,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        layout: &wgpu::BindGroupLayout,
+        material_params_buffer: &wgpu::Buffer,
+        gradient_sampler: &wgpu::Sampler,
+        backdrop_view: &wgpu::TextureView,
+        backdrop_sampler: &wgpu::Sampler,
+    ) -> wgpu::BindGroup {
+        let ramp_texture = if gradient_data.is_constant {
+            self.get_or_create_default_ramp_texture(device, queue)
+        } else {
+            self.get_or_create_ramp_texture(gradient_data, device, queue)
+        };
+
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Backdrop Gradient Material Bind Group"),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: material_params_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(ramp_texture.view.as_ref()),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(gradient_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(backdrop_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::Sampler(backdrop_sampler),
+                },
+            ],
+        })
     }
 
     fn trim(&mut self) {}

--- a/tests/visual_regression.rs
+++ b/tests/visual_regression.rs
@@ -42,6 +42,18 @@ fn assert_pixels_match(pixel_buffer: &[u8], expectations: &[grafo_test_scenes::P
     }
 }
 
+fn read_pixel_rgba(pixel_buffer: &[u8], width: u32, x: u32, y: u32) -> [u8; 4] {
+    let stride = (width as usize) * 4;
+    let offset = (y as usize) * stride + (x as usize) * 4;
+
+    [
+        pixel_buffer[offset + 2],
+        pixel_buffer[offset + 1],
+        pixel_buffer[offset],
+        pixel_buffer[offset + 3],
+    ]
+}
+
 /// Main regression test — renders all shared visual-regression tiles.
 #[test]
 fn main_scene_pixel_expectations() {
@@ -239,6 +251,121 @@ fn clipping_rect_clips_child_without_visible_surface() {
     ];
 
     assert_pixels_match(&pixel_buffer, &expectations);
+}
+
+/// Regression test — partially offscreen backdrop captures clear untouched pooled pixels.
+#[test]
+fn partially_offscreen_backdrop_capture_clears_reused_texture_space() {
+    let physical_size = (100, 80);
+    let Some(mut renderer) = create_headless_renderer_with_size_and_scale(physical_size, 1.0)
+    else {
+        return;
+    };
+
+    const AVERAGE_WITH_RIGHT_NEIGHBOR_EFFECT_ID: u64 = 9_101;
+    const AVERAGE_WITH_RIGHT_NEIGHBOR_WGSL: &str = r#"
+const LOOKAHEAD_UV: vec2<f32> = vec2<f32>(0.4, 0.0);
+
+@fragment
+fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    let base = textureSample(t_input, s_input, uv);
+    let lookahead = textureSample(t_input, s_input, uv + LOOKAHEAD_UV);
+    return 0.5 * (base + lookahead);
+}
+"#;
+
+    renderer
+        .load_effect(
+            AVERAGE_WITH_RIGHT_NEIGHBOR_EFFECT_ID,
+            &[AVERAGE_WITH_RIGHT_NEIGHBOR_WGSL],
+        )
+        .expect("Failed to compile deterministic backdrop test effect");
+
+    let seeded_blue_panel =
+        grafo::Shape::rect([(20.0, 20.0), (60.0, 60.0)], grafo::Stroke::default());
+    renderer
+        .add_shape(
+            seeded_blue_panel.clone(),
+            None,
+            None,
+            grafo::ShapeDrawCommandOptions::new().color(grafo::Color::rgb(40, 40, 220)),
+        )
+        .unwrap();
+    let seeded_blue_panel_id = renderer
+        .add_shape(
+            seeded_blue_panel,
+            None,
+            None,
+            grafo::ShapeDrawCommandOptions::new(),
+        )
+        .unwrap();
+    renderer
+        .set_shape_backdrop_effect(
+            seeded_blue_panel_id,
+            AVERAGE_WITH_RIGHT_NEIGHBOR_EFFECT_ID,
+            &[],
+            grafo::BackdropEffectConfig::new().capture_area(
+                grafo::BackdropCaptureArea::ScreenRect([(20.0, 20.0), (60.0, 60.0)]),
+            ),
+        )
+        .unwrap();
+
+    let mut seeded_frame: Vec<u8> = Vec::new();
+    renderer.render_to_buffer(&mut seeded_frame);
+
+    renderer.clear_draw_queue();
+
+    let visible_red_source =
+        grafo::Shape::rect([(70.0, 20.0), (100.0, 60.0)], grafo::Stroke::default());
+    renderer
+        .add_shape(
+            visible_red_source,
+            None,
+            None,
+            grafo::ShapeDrawCommandOptions::new().color(grafo::Color::rgb(220, 40, 40)),
+        )
+        .unwrap();
+
+    let partially_offscreen_panel =
+        grafo::Shape::rect([(70.0, 20.0), (100.0, 60.0)], grafo::Stroke::default());
+    let partially_offscreen_panel_id = renderer
+        .add_shape(
+            partially_offscreen_panel,
+            None,
+            None,
+            grafo::ShapeDrawCommandOptions::new(),
+        )
+        .unwrap();
+    renderer
+        .set_shape_backdrop_effect(
+            partially_offscreen_panel_id,
+            AVERAGE_WITH_RIGHT_NEIGHBOR_EFFECT_ID,
+            &[],
+            grafo::BackdropEffectConfig::new().capture_area(
+                grafo::BackdropCaptureArea::ScreenRect([(70.0, 20.0), (110.0, 60.0)]),
+            ),
+        )
+        .unwrap();
+
+    let mut pixel_buffer: Vec<u8> = Vec::new();
+    renderer.render_to_buffer(&mut pixel_buffer);
+
+    let sampled_pixel = read_pixel_rgba(&pixel_buffer, physical_size.0, 86, 40);
+    assert!(
+        sampled_pixel[0] > 80,
+        "expected visible red contribution after clearing untouched capture space, got {:?}",
+        sampled_pixel
+    );
+    assert!(
+        sampled_pixel[2] <= 50,
+        "expected offscreen capture space to stay transparent instead of leaking recycled blue, got {:?}",
+        sampled_pixel
+    );
+    assert!(
+        sampled_pixel[3] > 240,
+        "expected the cleared backdrop sample to composite back over the visible red source, got {:?}",
+        sampled_pixel
+    );
 }
 
 /// Regression test — standalone clipping rect is a no-op and does not enter shape drawing.


### PR DESCRIPTION
This PR:

-  adds a config for backdrop where you can specify which area to capture and how to downsample it;
- changes the default capture region from full screen to node bounds, so the effects are cheaper to render by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passthrough backdrop effect and explicit backdrop capture/padding controls for finer backdrop sampling.
  * Material-backed backdrop sampling so fills and gradients can composite captured backdrop textures.

* **Refactor**
  * Reworked offscreen capture, blit pipeline, and pooled texture handling to improve backdrop capture accuracy and avoid stale bleed.

* **Tests**
  * Expanded unit and visual-regression tests for capture regions, downsampling, padding, offscreen bounds, and compositing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->