### PR TITLE
fix: gradient banding and filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "euclid",
  "futures",
  "grafo-test-scenes",
+ "half",
  "image",
  "lru",
  "lyon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "grafo"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "grafo-test-scenes"]
 
 [package]
 name = "grafo"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 description = "A GPU-accelerated rendering library for Rust"
 keywords = ["rendering", "vector_graphics", "gui", "graphics", "image"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ regex = "1"
 softbuffer = "0.4.8"
 thiserror = "2.0.18"
 smallvec = "1.13"
+half = "2.4"
 
 [dev-dependencies]
 winit = "0.30"

--- a/src/gradient/gpu.rs
+++ b/src/gradient/gpu.rs
@@ -211,10 +211,16 @@ pub(crate) fn create_ramp_texture(
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D1,
-        format: wgpu::TextureFormat::Rgba32Float,
+        // Use half floats so the ramp stays high precision while remaining filterable.
+        format: wgpu::TextureFormat::Rgba16Float,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
     });
+
+    let upload_ramp: Vec<[u16; 4]> = ramp
+        .iter()
+        .map(|texel| texel.map(|channel| half::f16::from_f32(channel).to_bits()))
+        .collect();
 
     queue.write_texture(
         wgpu::TexelCopyTextureInfo {
@@ -223,10 +229,10 @@ pub(crate) fn create_ramp_texture(
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
         },
-        bytemuck::cast_slice(ramp),
+        bytemuck::cast_slice(&upload_ramp),
         wgpu::TexelCopyBufferLayout {
             offset: 0,
-            bytes_per_row: Some(width * 16), // 4 × f32 = 16 bytes per texel
+            bytes_per_row: Some(width * 8), // 4 × f16 = 8 bytes per texel
             rows_per_image: None,
         },
         wgpu::Extent3d {

--- a/src/gradient/types.rs
+++ b/src/gradient/types.rs
@@ -547,7 +547,7 @@ impl From<Gradient> for Fill {
 // ── Validated opaque Gradient ────────────────────────────────────────────────
 
 /// The number of texels in a baked gradient ramp texture.
-pub(crate) const RAMP_RESOLUTION: usize = 256;
+pub(crate) const RAMP_RESOLUTION: usize = 1024;
 
 #[derive(Debug, Clone)]
 pub struct Gradient {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -232,14 +232,14 @@ pub fn create_gradient_bind_group_layout(device: &Device) -> BindGroupLayout {
                 ty: wgpu::BindingType::Texture {
                     multisampled: false,
                     view_dimension: wgpu::TextureViewDimension::D1,
-                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
                 },
                 count: None,
             },
             wgpu::BindGroupLayoutEntry {
                 binding: 2,
                 visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                 count: None,
             },
         ],
@@ -300,14 +300,14 @@ pub fn create_backdrop_gradient_bind_group_layout(device: &Device) -> BindGroupL
                 ty: wgpu::BindingType::Texture {
                     multisampled: false,
                     view_dimension: wgpu::TextureViewDimension::D1,
-                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
                 },
                 count: None,
             },
             wgpu::BindGroupLayoutEntry {
                 binding: 2,
                 visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                 count: None,
             },
             wgpu::BindGroupLayoutEntry {

--- a/src/renderer/construction.rs
+++ b/src/renderer/construction.rs
@@ -230,8 +230,8 @@ impl<'a> Renderer<'a> {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
@@ -791,8 +791,8 @@ impl<'a> Renderer<'a> {
         self.gradient_ramp_sampler = self.device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("gradient_ramp_sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         });
         self.and_gradient_pipeline = Arc::new(crate::pipeline::create_gradient_increment_pipeline(

--- a/src/shaders/shader.wgsl
+++ b/src/shaders/shader.wgsl
@@ -415,8 +415,12 @@ fn compute_gradient_fragment_color(
     texture_flags: f32,
     model_pos: vec2<f32>,
     screen_pos: vec2<f32>,
+    dither_coords: vec2<f32>,
 ) -> vec4<f32> {
-    let fill_pma = evaluate_gradient(model_pos, screen_pos);
+    let fill_pma = apply_gradient_bayer_dither(
+        evaluate_gradient(model_pos, screen_pos),
+        dither_coords,
+    );
 
     let flags = u32(texture_flags);
     if (flags == 0u) {
@@ -476,7 +480,10 @@ fn compute_gradient_fragment_color_with_backdrop(
     model_pos: vec2<f32>,
     screen_pos: vec2<f32>,
 ) -> vec4<f32> {
-    let fill_pma = evaluate_gradient(model_pos, screen_pos);
+    let fill_pma = apply_gradient_bayer_dither(
+        evaluate_gradient(model_pos, screen_pos),
+        fragment_position.xy,
+    );
     let backdrop_uv = (fragment_position.xy - material_params.backdrop_sampling.capture_origin)
         * material_params.backdrop_sampling.inverse_capture_size;
     let backdrop_pma = textureSampleLevel(t_backdrop_layer, s_backdrop_layer, backdrop_uv, 0.0);
@@ -525,14 +532,15 @@ fn fs_main_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return apply_gradient_bayer_dither(compute_gradient_fragment_color(
+    return compute_gradient_fragment_color(
         layer0_tex_coords,
         layer1_tex_coords,
         coverage,
         texture_flags,
         model_pos,
         screen_pos,
-    ), fragment_position.xy);
+        fragment_position.xy,
+    );
 }
 
 // Used by stencil-only passes that write no color. Color work is skipped entirely;
@@ -574,14 +582,15 @@ fn fs_passthrough_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return apply_gradient_bayer_dither(compute_gradient_fragment_color(
+    return compute_gradient_fragment_color(
         layer0_tex_coords,
         layer1_tex_coords,
         coverage,
         texture_flags,
         model_pos,
         screen_pos,
-    ), fragment_position.xy);
+        fragment_position.xy,
+    );
 }
 
 @fragment
@@ -614,7 +623,7 @@ fn fs_backdrop_passthrough_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return apply_gradient_bayer_dither(compute_gradient_fragment_color_with_backdrop(
+    return compute_gradient_fragment_color_with_backdrop(
         fragment_position,
         layer0_tex_coords,
         layer1_tex_coords,
@@ -622,5 +631,5 @@ fn fs_backdrop_passthrough_gradient(
         texture_flags,
         model_pos,
         screen_pos,
-    ), fragment_position.xy);
+    );
 }

--- a/src/shaders/shader.wgsl
+++ b/src/shaders/shader.wgsl
@@ -113,6 +113,31 @@ fn to_srgb(color: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, color <= cutoff);
 }
 
+const BAYER_4X4_THRESHOLDS: array<f32, 16> = array<f32, 16>(
+    0.0, 8.0, 2.0, 10.0,
+    12.0, 4.0, 14.0, 6.0,
+    3.0, 11.0, 1.0, 9.0,
+    15.0, 7.0, 13.0, 5.0,
+);
+
+fn bayer_4x4_threshold(pixel_pos: vec2<f32>) -> f32 {
+    let x = u32(pixel_pos.x) & 3u;
+    let y = u32(pixel_pos.y) & 3u;
+    return (BAYER_4X4_THRESHOLDS[y * 4u + x] + 0.5) * (1.0 / 16.0);
+}
+
+fn apply_gradient_bayer_dither(color_pma: vec4<f32>, pixel_pos: vec2<f32>) -> vec4<f32> {
+    if color_pma.a <= 1e-6 {
+        return color_pma;
+    }
+
+    let alpha = color_pma.a;
+    let rgb = color_pma.rgb / alpha;
+    let offset = (bayer_4x4_threshold(pixel_pos) - 0.5) * (1.0 / 255.0);
+    let dithered_rgb = clamp(rgb + vec3<f32>(offset), vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(dithered_rgb * alpha, alpha);
+}
+
 // ── Gradient evaluation ─────────────────────────────────────────────
 
 /// Computes the raw gradient parameter t for the given position.
@@ -491,6 +516,7 @@ fn fs_main(
 
 @fragment
 fn fs_main_gradient(
+    @builtin(position) fragment_position: vec4<f32>,
     @location(0) color: vec4<f32>,
     @location(1) layer0_tex_coords: vec2<f32>,
     @location(2) layer1_tex_coords: vec2<f32>,
@@ -499,14 +525,14 @@ fn fs_main_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return compute_gradient_fragment_color(
+    return apply_gradient_bayer_dither(compute_gradient_fragment_color(
         layer0_tex_coords,
         layer1_tex_coords,
         coverage,
         texture_flags,
         model_pos,
         screen_pos,
-    );
+    ), fragment_position.xy);
 }
 
 // Used by stencil-only passes that write no color. Color work is skipped entirely;
@@ -539,6 +565,7 @@ fn fs_passthrough(
 
 @fragment
 fn fs_passthrough_gradient(
+    @builtin(position) fragment_position: vec4<f32>,
     @location(0) color: vec4<f32>,
     @location(1) layer0_tex_coords: vec2<f32>,
     @location(2) layer1_tex_coords: vec2<f32>,
@@ -547,14 +574,14 @@ fn fs_passthrough_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return compute_gradient_fragment_color(
+    return apply_gradient_bayer_dither(compute_gradient_fragment_color(
         layer0_tex_coords,
         layer1_tex_coords,
         coverage,
         texture_flags,
         model_pos,
         screen_pos,
-    );
+    ), fragment_position.xy);
 }
 
 @fragment
@@ -587,7 +614,7 @@ fn fs_backdrop_passthrough_gradient(
     @location(5) model_pos: vec2<f32>,
     @location(6) screen_pos: vec2<f32>,
 ) -> @location(0) vec4<f32> {
-    return compute_gradient_fragment_color_with_backdrop(
+    return apply_gradient_bayer_dither(compute_gradient_fragment_color_with_backdrop(
         fragment_position,
         layer0_tex_coords,
         layer1_tex_coords,
@@ -595,5 +622,5 @@ fn fs_backdrop_passthrough_gradient(
         texture_flags,
         model_pos,
         screen_pos,
-    );
+    ), fragment_position.xy);
 }


### PR DESCRIPTION
This PR introduces some changes to gradients to make them look smoother:
- Increases gradient ramp size from 256 to 1024;
- Enabled linear filtering for gradient ramp textures;
- Adds a cheap form of dithering to further smooth the appearance of the gradient.

Tested on a low end Android device, no significant performance degradation observed, while increase the quality of the gradient output substantially

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced gradient rendering quality with 4x higher resolution for smoother color transitions
  * Added dithering to reduce color banding artifacts in gradients
  * Improved gradient smoothness through linear texture filtering

* **Performance**
  * Reduced memory usage for gradient textures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antouhou/grafo/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->