### PR TITLE
fix: don't skip non-leaf effect draws

### DIFF
--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -4115,6 +4115,21 @@ fn tile_60_cached_shape_effect_rect(renderer: &mut Renderer) -> Vec<PixelExpecta
             ShapeDrawCommandOptions::new().color(Color::rgb(220, 50, 50)),
         )
         .unwrap();
+    let transparent_child = Shape::rect(
+        [
+            (origin_x + 30.0, origin_y + 30.0),
+            (origin_x + 40.0, origin_y + 40.0),
+        ],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            transparent_child,
+            Some(shape_id),
+            None,
+            ShapeDrawCommandOptions::new().color(Color::TRANSPARENT),
+        )
+        .unwrap();
     renderer
         .set_shape_effect(
             shape_id,

--- a/src/renderer/shape_effects.rs
+++ b/src/renderer/shape_effects.rs
@@ -407,9 +407,6 @@ impl<'a> Renderer<'a> {
             let Some(draw_command) = self.draw_tree.get(node_id) else {
                 continue;
             };
-            if !draw_command.is_leaf() {
-                continue;
-            }
             let DrawCommand::CachedShape(source_shape) = draw_command else {
                 continue;
             };

--- a/src/renderer/traversal.rs
+++ b/src/renderer/traversal.rs
@@ -75,7 +75,7 @@ pub(super) fn plan_traversal_in_place(
 
     let exclude_id = exclude_subtree_id;
 
-    let pre_fn = |node_id: usize, draw_command: &mut DrawCommand, state: &mut TraversalScratch| {
+    let pre_fn = |node_id: usize, _draw_command: &mut DrawCommand, state: &mut TraversalScratch| {
         // Handle excluded subtree: skip the node and all descendants entirely.
         if state.excluded_depth > 0 {
             state.excluded_depth += 1;
@@ -94,8 +94,7 @@ pub(super) fn plan_traversal_in_place(
             return;
         }
 
-        if draw_command.is_leaf()
-            && !effect_results.contains_key(&node_id)
+        if !effect_results.contains_key(&node_id)
             && prepared_shape_effect_leaves.contains_key(&node_id)
         {
             state.events.push(TraversalEvent::PreparedLeaf(node_id));
@@ -235,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn plan_traversal_ignores_prepared_leaf_for_node_with_children() {
+    fn plan_traversal_inserts_prepared_leaf_before_node_with_children() {
         let mut tree = easy_tree::Tree::new();
         let root = tree.add_node(DrawCommand::CachedShape(cached_draw_data()));
         tree.get_mut(root).unwrap().set_not_leaf();
@@ -257,6 +256,7 @@ mod tests {
         assert_eq!(
             traversal_scratch.events(),
             &[
+                TraversalEvent::PreparedLeaf(root),
                 TraversalEvent::Pre(root),
                 TraversalEvent::Pre(child),
                 TraversalEvent::Post(child),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering of shape effects on cached shapes that contain nested content.
  - Corrected traversal ordering so prepared rendering steps occur before processing a node’s children.
  - Fixed scenarios where shape effects were skipped for non-leaf elements, improving visual consistency in complex scenes.
- **Tests**
  - Updated rendering coverage to verify shape effects and traversal behavior for nested shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->