### PR TITLE
feat: add downsampling to the shape effect

### DIFF
--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -293,7 +293,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -293,20 +293,17 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.
                         renderer.clear_draw_queue();
                         window.request_redraw();
-
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -110,6 +110,17 @@ impl<'a> ApplicationHandler for App<'a> {
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
                     ) => renderer.resize(renderer.size()),
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or
+                        // fully covered). Ask for another redraw instead of dropping the
+                        // frame for good — winit does not request one when the window
+                        // becomes visible again.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/bench_render_loop.rs
+++ b/examples/bench_render_loop.rs
@@ -485,7 +485,27 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                 match self.phase {
                     Phase::WarmupStatic => {
                         let renderer = self.renderer.as_mut().unwrap();
-                        renderer.render().expect("render failed");
+                        match renderer.render() {
+                            Ok(_) => {}
+                            Err(
+                                wgpu::CurrentSurfaceTexture::Timeout
+                                | wgpu::CurrentSurfaceTexture::Occluded,
+                            ) => {
+                                // Window not visible — skip without counting the frame.
+                                window.request_redraw();
+                                return;
+                            }
+                            Err(
+                                wgpu::CurrentSurfaceTexture::Lost
+                                | wgpu::CurrentSurfaceTexture::Outdated,
+                            ) => {
+                                let size = renderer.size();
+                                renderer.resize(size);
+                                window.request_redraw();
+                                return;
+                            }
+                            Err(e) => panic!("render failed: {e:?}"),
+                        }
                         self.frame_counter += 1;
                         if self.frame_counter >= WARMUP_FRAMES {
                             #[cfg(feature = "render_metrics")]
@@ -501,7 +521,27 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                         {
                             let renderer = self.renderer.as_mut().unwrap();
                             let frame_start = Instant::now();
-                            renderer.render().expect("render failed");
+                            match renderer.render() {
+                                Ok(_) => {}
+                                Err(
+                                    wgpu::CurrentSurfaceTexture::Timeout
+                                    | wgpu::CurrentSurfaceTexture::Occluded,
+                                ) => {
+                                    // Window not visible — skip without measuring the frame.
+                                    window.request_redraw();
+                                    return;
+                                }
+                                Err(
+                                    wgpu::CurrentSurfaceTexture::Lost
+                                    | wgpu::CurrentSurfaceTexture::Outdated,
+                                ) => {
+                                    let size = renderer.size();
+                                    renderer.resize(size);
+                                    window.request_redraw();
+                                    return;
+                                }
+                                Err(e) => panic!("render failed: {e:?}"),
+                            }
                             self.static_frame_times.push(frame_start.elapsed());
 
                             #[cfg(feature = "render_metrics")]
@@ -528,7 +568,29 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                     Phase::WarmupDynamic => {
                         let renderer = self.renderer.as_mut().unwrap();
                         build_scene(renderer);
-                        renderer.render().expect("render failed");
+                        match renderer.render() {
+                            Ok(_) => {}
+                            Err(
+                                wgpu::CurrentSurfaceTexture::Timeout
+                                | wgpu::CurrentSurfaceTexture::Occluded,
+                            ) => {
+                                // Window not visible — skip without counting the frame.
+                                renderer.clear_draw_queue();
+                                window.request_redraw();
+                                return;
+                            }
+                            Err(
+                                wgpu::CurrentSurfaceTexture::Lost
+                                | wgpu::CurrentSurfaceTexture::Outdated,
+                            ) => {
+                                renderer.clear_draw_queue();
+                                let size = renderer.size();
+                                renderer.resize(size);
+                                window.request_redraw();
+                                return;
+                            }
+                            Err(e) => panic!("render failed: {e:?}"),
+                        }
                         renderer.clear_draw_queue();
                         self.frame_counter += 1;
                         if self.frame_counter >= WARMUP_FRAMES {
@@ -549,7 +611,29 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                             self.dynamic_rebuild_times.push(rebuild_start.elapsed());
 
                             let frame_start = Instant::now();
-                            renderer.render().expect("render failed");
+                            match renderer.render() {
+                                Ok(_) => {}
+                                Err(
+                                    wgpu::CurrentSurfaceTexture::Timeout
+                                    | wgpu::CurrentSurfaceTexture::Occluded,
+                                ) => {
+                                    // Window not visible — skip without measuring the frame.
+                                    renderer.clear_draw_queue();
+                                    window.request_redraw();
+                                    return;
+                                }
+                                Err(
+                                    wgpu::CurrentSurfaceTexture::Lost
+                                    | wgpu::CurrentSurfaceTexture::Outdated,
+                                ) => {
+                                    renderer.clear_draw_queue();
+                                    let size = renderer.size();
+                                    renderer.resize(size);
+                                    window.request_redraw();
+                                    return;
+                                }
+                                Err(e) => panic!("render failed: {e:?}"),
+                            }
                             self.dynamic_frame_times.push(frame_start.elapsed());
 
                             #[cfg(feature = "render_metrics")]

--- a/examples/bench_render_loop.rs
+++ b/examples/bench_render_loop.rs
@@ -608,7 +608,7 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                             let renderer = self.renderer.as_mut().unwrap();
                             let rebuild_start = Instant::now();
                             build_scene(renderer);
-                            self.dynamic_rebuild_times.push(rebuild_start.elapsed());
+                            let rebuild_duration = rebuild_start.elapsed();
 
                             let frame_start = Instant::now();
                             match renderer.render() {
@@ -634,6 +634,7 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                                 }
                                 Err(e) => panic!("render failed: {e:?}"),
                             }
+                            self.dynamic_rebuild_times.push(rebuild_duration);
                             self.dynamic_frame_times.push(frame_start.elapsed());
 
                             #[cfg(feature = "render_metrics")]

--- a/examples/box_shadow.rs
+++ b/examples/box_shadow.rs
@@ -307,20 +307,17 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.
                         renderer.clear_draw_queue();
                         window.request_redraw();
-
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }

--- a/examples/box_shadow.rs
+++ b/examples/box_shadow.rs
@@ -307,7 +307,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/gaussian_blur.rs
+++ b/examples/gaussian_blur.rs
@@ -275,7 +275,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/gaussian_blur.rs
+++ b/examples/gaussian_blur.rs
@@ -275,20 +275,17 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.
                         renderer.clear_draw_queue();
                         window.request_redraw();
-
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -230,6 +230,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -198,7 +198,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -14,18 +14,25 @@ use futures::executor::block_on;
 use grafo::Shape;
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
 
 const OPACITY_EFFECT: u64 = 1;
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Default)]
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
     effect_loaded: bool,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> ApplicationHandler for App<'a> {
@@ -194,29 +201,45 @@ impl<'a> ApplicationHandler for App<'a> {
                 // ── Render ───────────────────────────────────────────────
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -180,7 +180,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -6,16 +6,23 @@ use futures::executor::block_on;
 use grafo::{BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, KeyEvent, WindowEvent};
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
     msaa_enabled: bool,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> Default for App<'a> {
@@ -24,6 +31,7 @@ impl<'a> Default for App<'a> {
             window: None,
             renderer: None,
             msaa_enabled: true,
+            redraw_retry_at: None,
         }
     }
 }
@@ -176,29 +184,45 @@ impl<'a> ApplicationHandler for App<'a> {
 
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -213,6 +213,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -8,6 +8,7 @@ use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::window::Window;
 
 struct App {
+    window: Option<Arc<Window>>,
     renderer: Option<Renderer<'static>>,
     bg_tex_id: u64,
     fg_tex_id: u64,
@@ -16,6 +17,7 @@ struct App {
 impl Default for App {
     fn default() -> Self {
         Self {
+            window: None,
             renderer: None,
             bg_tex_id: 100,
             fg_tex_id: 101,
@@ -33,7 +35,7 @@ impl ApplicationHandler for App {
         let physical_size = (800, 600);
         let scale_factor = 1.0;
         let mut renderer = futures::executor::block_on(Renderer::new(
-            window,
+            window.clone(),
             physical_size,
             scale_factor,
             true,
@@ -98,21 +100,52 @@ impl ApplicationHandler for App {
                     .foreground_texture_id(self.fg_tex_id),
             )
             .unwrap();
+        self.window = Some(window);
         self.renderer = Some(renderer);
-
-        if let Some(r) = self.renderer.as_mut() {
-            let _ = r.render();
-            r.clear_draw_queue();
-        }
     }
 
     fn window_event(
         &mut self,
-        _event_loop: &ActiveEventLoop,
+        event_loop: &ActiveEventLoop,
         _id: winit::window::WindowId,
-        _event: winit::event::WindowEvent,
+        event: winit::event::WindowEvent,
     ) {
-        // No interactivity in this minimal example; a real app would handle events here.
+        use winit::event::WindowEvent;
+
+        let (Some(window), Some(renderer)) = (&self.window, &mut self.renderer) else {
+            return;
+        };
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(physical_size) => {
+                renderer.resize((physical_size.width, physical_size.height));
+                window.request_redraw();
+            }
+            WindowEvent::RedrawRequested => {
+                // The draw queue is populated once in `resumed` and persists across frames.
+                match renderer.render() {
+                    Ok(_) => {}
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+                    ) => {
+                        let size = renderer.size();
+                        renderer.resize(size);
+                    }
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        window.request_redraw();
+                    }
+                    Err(e) => eprintln!("{e:?}"),
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -3,15 +3,22 @@
 
 use grafo::{Color, Renderer, Shape, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::Window;
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 struct App {
     window: Option<Arc<Window>>,
     renderer: Option<Renderer<'static>>,
     bg_tex_id: u64,
     fg_tex_id: u64,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl Default for App {
@@ -21,6 +28,7 @@ impl Default for App {
             renderer: None,
             bg_tex_id: 100,
             fg_tex_id: 101,
+            redraw_retry_at: None,
         }
     }
 }
@@ -125,7 +133,9 @@ impl ApplicationHandler for App {
             WindowEvent::RedrawRequested => {
                 // The draw queue is populated once in `resumed` and persists across frames.
                 match renderer.render() {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        self.redraw_retry_at = None;
+                    }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
                     ) => {
@@ -137,14 +147,32 @@ impl ApplicationHandler for App {
                         | wgpu::CurrentSurfaceTexture::Occluded,
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
-                        window.request_redraw();
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -163,6 +163,9 @@ impl ApplicationHandler for App {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -399,6 +399,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -367,7 +367,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -15,13 +15,18 @@ use futures::executor::block_on;
 use grafo::{BackdropEffectConfig, BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
 
 const BOX_SHADOW_EFFECT: u64 = 1;
 const BLUR_EFFECT: u64 = 2;
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 // ── Box shadow params & shader ───────────────────────────────────────────────
 
@@ -160,6 +165,8 @@ fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> ApplicationHandler for App<'a> {
@@ -363,29 +370,45 @@ impl<'a> ApplicationHandler for App<'a> {
                 // ── Render ───────────────────────────────────────────────
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -143,7 +143,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
                 println!("Render time: {:?}", timer.elapsed());

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -179,6 +179,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -3,17 +3,23 @@ use grafo::{BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use image::ImageReader;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
     rust_logo_png_bytes: Vec<u8>,
     rust_logo_png_dimensions: (u32, u32),
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> Default for App<'a> {
@@ -33,6 +39,7 @@ impl<'a> Default for App<'a> {
             renderer: None,
             rust_logo_png_bytes,
             rust_logo_png_dimensions,
+            redraw_retry_at: None,
         }
     }
 }
@@ -139,24 +146,25 @@ impl<'a> ApplicationHandler for App<'a> {
                 let timer = Instant::now();
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
@@ -166,6 +174,21 @@ impl<'a> ApplicationHandler for App<'a> {
                 renderer.change_scale_factor(scale_factor);
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/star_wars_tilt.rs
+++ b/examples/star_wars_tilt.rs
@@ -228,7 +228,29 @@ impl<'a> ApplicationHandler for App<'a> {
                         )
                         .unwrap();
 
-                    renderer.render().unwrap();
+                    match renderer.render() {
+                        Ok(_) => {}
+                        Err(
+                            wgpu::CurrentSurfaceTexture::Lost
+                            | wgpu::CurrentSurfaceTexture::Outdated,
+                        ) => {
+                            let size = renderer.size();
+                            renderer.resize(size);
+                        }
+                        Err(
+                            wgpu::CurrentSurfaceTexture::Timeout
+                            | wgpu::CurrentSurfaceTexture::Occluded,
+                        ) => {
+                            // The window is not visible yet (still appearing, minimized, or
+                            // fully covered). Ask for another redraw instead of dropping the
+                            // frame for good — winit does not request one when the window
+                            // becomes visible again.
+                            if let Some(window) = &self.window {
+                                window.request_redraw();
+                            }
+                        }
+                        Err(e) => eprintln!("{e:?}"),
+                    }
                 }
             }
             WindowEvent::Resized(new_size) => {

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -639,6 +639,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -607,7 +607,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -8,6 +8,7 @@ use lyon::geom::point;
 use lyon::path::FillRule;
 use lyon::path::Path;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 // Local converter from euclid to grafo's GPU instance layout so we keep euclid out of the main crate.
 fn transform_instance_from_euclid(m: Transform3D<f32>) -> grafo::TransformInstance {
@@ -78,7 +79,7 @@ fn world_to_local_2d(tx: &Transform3D<f32>, world: (f32, f32)) -> Option<(f32, f
 }
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
 
@@ -123,10 +124,16 @@ fn build_perspective_demo_path() -> Path {
     pb.build()
 }
 
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
+
 #[derive(Default)]
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
     angle: f32,
     // Last mouse position in physical pixels (window space)
     last_mouse_pos: Option<(f32, f32)>,
@@ -602,30 +609,46 @@ impl<'a> ApplicationHandler for App<'a> {
 
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                         window.request_redraw();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }
@@ -638,6 +661,7 @@ pub fn main() {
     let mut app = App {
         window: None,
         renderer: None,
+        redraw_retry_at: None,
         angle: 0.0,
         last_mouse_pos: None,
         orbit_yaw_deg: 0.0,

--- a/examples/video_playback.rs
+++ b/examples/video_playback.rs
@@ -111,6 +111,13 @@ pub fn main() {
     //                         renderer.clear_draw_queue();
     //                     }
     //                     Err(wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated) => renderer.resize(renderer.size()),
+    //                     Err(wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded) => {
+    //                         // The window is not visible yet (still appearing, minimized, or fully
+    //                         // covered). Ask for another redraw instead of dropping the frame for
+    //                         // good — winit does not request one when the window becomes visible.
+    //                         renderer.clear_draw_queue();
+    //                         window.request_redraw();
+    //                     }
     //                     Err(e) => eprintln!("{:?}", e),
     //                 }
     //             }

--- a/examples/visual_test_grid.rs
+++ b/examples/visual_test_grid.rs
@@ -7,15 +7,22 @@
 use futures::executor::block_on;
 use grafo_test_scenes::{build_main_scene, CANVAS_HEIGHT, CANVAS_WIDTH};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Default)]
 struct App<'a> {
     window: Option<Arc<Window>>,
     renderer: Option<grafo::Renderer<'a>>,
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> ApplicationHandler for App<'a> {
@@ -72,7 +79,9 @@ impl<'a> ApplicationHandler for App<'a> {
                 build_main_scene(renderer);
 
                 match renderer.render() {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        self.redraw_retry_at = None;
+                    }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
                     ) => renderer.resize(renderer.size()),
@@ -81,14 +90,32 @@ impl<'a> ApplicationHandler for App<'a> {
                         | wgpu::CurrentSurfaceTexture::Occluded,
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
-                        window.request_redraw();
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/visual_test_grid.rs
+++ b/examples/visual_test_grid.rs
@@ -106,6 +106,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/visual_test_grid.rs
+++ b/examples/visual_test_grid.rs
@@ -76,6 +76,15 @@ impl<'a> ApplicationHandler for App<'a> {
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
                     ) => renderer.resize(renderer.size()),
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        window.request_redraw();
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
             }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -3,11 +3,15 @@ use grafo::{BorderRadii, Shape};
 use grafo::{Color, ShapeDrawCommandOptions, Stroke};
 use image::ImageReader;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
+
+/// How long to wait before retrying a frame that was skipped because the surface
+/// reported it was not visible (`Occluded`/`Timeout`).
+const OCCLUDED_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 struct App<'a> {
     window: Option<Arc<Window>>,
@@ -15,6 +19,8 @@ struct App<'a> {
     rust_logo_png_bytes: Vec<u8>,
     rust_logo_png_dimensions: (u32, u32),
     rust_logo_png_dimensions_f32: (f32, f32),
+    /// Pending retry of a frame skipped because the window was not visible.
+    redraw_retry_at: Option<Instant>,
 }
 
 impl<'a> Default for App<'a> {
@@ -39,6 +45,7 @@ impl<'a> Default for App<'a> {
             rust_logo_png_bytes,
             rust_logo_png_dimensions,
             rust_logo_png_dimensions_f32,
+            redraw_retry_at: None,
         }
     }
 }
@@ -262,24 +269,25 @@ impl<'a> ApplicationHandler for App<'a> {
                 let timer = Instant::now();
                 match renderer.render() {
                     Ok(_) => {
+                        self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-
                     ) => renderer.resize(renderer.size()),
 
                     Err(
                         wgpu::CurrentSurfaceTexture::Timeout
                         | wgpu::CurrentSurfaceTexture::Occluded,
-
                     ) => {
                         // The window is not visible yet (still appearing, minimized, or fully
-                        // covered). Ask for another redraw instead of dropping the frame for
-                        // good — winit does not request one when the window becomes visible.
+                        // covered). Retry shortly instead of busy-looping redraws — winit does
+                        // not request one when the window becomes visible again. `WaitUntil`
+                        // wakes the event loop without spinning while the window stays hidden.
                         renderer.clear_draw_queue();
-                        window.request_redraw();
-
+                        let retry_at = Instant::now() + OCCLUDED_RETRY_DELAY;
+                        self.redraw_retry_at = Some(retry_at);
+                        event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
                     }
                     Err(e) => eprintln!("{e:?}"),
                 }
@@ -289,6 +297,21 @@ impl<'a> ApplicationHandler for App<'a> {
                 renderer.change_scale_factor(scale_factor);
             }
             _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(retry_at) = self.redraw_retry_at else {
+            return;
+        };
+        if Instant::now() >= retry_at {
+            self.redraw_retry_at = None;
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+            event_loop.set_control_flow(ControlFlow::Wait);
+        } else {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(retry_at));
         }
     }
 }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -302,6 +302,9 @@ impl<'a> ApplicationHandler for App<'a> {
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         let Some(retry_at) = self.redraw_retry_at else {
+            // Clear a stale WaitUntil deadline left behind when a successful
+            // render cancelled the pending retry before it fired.
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         };
         if Instant::now() >= retry_at {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -266,7 +266,21 @@ impl<'a> ApplicationHandler for App<'a> {
                     }
                     Err(
                         wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+
                     ) => renderer.resize(renderer.size()),
+
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+
+                    }
                     Err(e) => eprintln!("{e:?}"),
                 }
                 println!("Render time: {:?}", timer.elapsed());

--- a/examples/winit_transparency.rs
+++ b/examples/winit_transparency.rs
@@ -108,6 +108,16 @@ impl<'a> ApplicationHandler for App<'a> {
                         println!("Surface lost or outdated, resizing...");
                         renderer.resize(renderer.size())
                     }
+                    Err(
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded,
+                    ) => {
+                        // The window is not visible yet (still appearing, minimized, or fully
+                        // covered). Ask for another redraw instead of dropping the frame for
+                        // good — winit does not request one when the window becomes visible.
+                        renderer.clear_draw_queue();
+                        window.request_redraw();
+                    }
                     Err(e) => eprintln!("Render error: {e:?}"),
                 }
             }

--- a/grafo-test-scenes/src/scene.rs
+++ b/grafo-test-scenes/src/scene.rs
@@ -9,15 +9,17 @@ use grafo::{
 
 use crate::expectations::PixelExpectation;
 use crate::shaders::{
-    BlurParams, DROP_SHADOW_HORIZONTAL_BLUR_WGSL, DROP_SHADOW_VERTICAL_TINT_WGSL,
-    HORIZONTAL_BLUR_WGSL, PASSTHROUGH_WGSL, SHAPE_DROP_WGSL, VERTICAL_BLUR_WGSL,
+    BlurParams, DOWNSAMPLED_DROP_SHADOW_HORIZONTAL_BLUR_WGSL,
+    DOWNSAMPLED_DROP_SHADOW_VERTICAL_TINT_WGSL, DROP_SHADOW_HORIZONTAL_BLUR_WGSL,
+    DROP_SHADOW_VERTICAL_TINT_WGSL, HORIZONTAL_BLUR_WGSL, PASSTHROUGH_WGSL, SHAPE_DROP_WGSL,
+    VERTICAL_BLUR_WGSL,
 };
 
 // ── Grid layout constants ────────────────────────────────────────────────────
 
 const TILE_SIZE: u32 = 80;
 const COLUMNS: u32 = 6;
-const ROWS: u32 = 11;
+const ROWS: u32 = 12;
 
 pub const CANVAS_WIDTH: u32 = TILE_SIZE * COLUMNS;
 pub const CANVAS_HEIGHT: u32 = TILE_SIZE * ROWS;
@@ -26,6 +28,7 @@ const BLUR_EFFECT_ID: u64 = 1;
 const PASSTHROUGH_EFFECT_ID: u64 = 2;
 const SHAPE_DROP_EFFECT_ID: u64 = 3;
 const DROP_SHADOW_EFFECT_ID: u64 = 4;
+const DOWNSAMPLED_DROP_SHADOW_EFFECT_ID: u64 = 5;
 const CHECKERBOARD_TEXTURE_ID: u64 = 100;
 const SOLID_GREEN_TEXTURE_ID: u64 = 101;
 const SOLID_GREEN_20X20_TEXTURE_ID: u64 = 102;
@@ -138,6 +141,7 @@ pub fn build_main_scene(renderer: &mut Renderer) -> Vec<PixelExpectation> {
     expectations.extend(tile_64_drop_shadow_with_backdrop_blur(renderer));
     expectations.extend(tile_65_grouped_shape_effect_in_backdrop(renderer));
     expectations.extend(tile_66_same_node_shape_backdrop_and_group_effects(renderer));
+    expectations.extend(tile_67_downsampled_drop_shadow_with_backdrop_blur(renderer));
 
     expectations
 }
@@ -163,6 +167,15 @@ fn load_shared_resources(renderer: &mut Renderer) {
             ],
         )
         .expect("Failed to compile visual drop shadow effect");
+    renderer
+        .load_effect(
+            DOWNSAMPLED_DROP_SHADOW_EFFECT_ID,
+            &[
+                DOWNSAMPLED_DROP_SHADOW_HORIZONTAL_BLUR_WGSL,
+                DOWNSAMPLED_DROP_SHADOW_VERTICAL_TINT_WGSL,
+            ],
+        )
+        .expect("Failed to compile downsampled drop shadow effect");
 
     // 4×4 checkerboard: alternating white and black pixels, RGBA
     let mut checkerboard = [0u8; 4 * 4 * 4];
@@ -4657,6 +4670,151 @@ fn tile_66_same_node_shape_backdrop_and_group_effects(
             180,
             80,
             "t66_scene_behind_group_remains_unprocessed",
+        ),
+    ]
+}
+
+/// Tile 67 — Tile 64 rendered at half mask resolution: the drop shadow is
+/// rasterized into a half-size texture and bilinearly upscaled when drawn.
+/// Shader sigma and offset are halved so the result should match tile 64
+/// on screen, with slightly softer edges from the upscale.
+fn tile_67_downsampled_drop_shadow_with_backdrop_blur(
+    renderer: &mut Renderer,
+) -> Vec<PixelExpectation> {
+    let (origin_x, origin_y) = tile_origin(67);
+    let backing_shape = Shape::rect(
+        [
+            (origin_x + 6.0, origin_y + 6.0),
+            (origin_x + 72.0, origin_y + 42.0),
+        ],
+        Stroke::default(),
+    );
+    renderer
+        .add_shape(
+            backing_shape,
+            None,
+            None,
+            ShapeDrawCommandOptions::new().color(Color::rgb(245, 190, 70)),
+        )
+        .unwrap();
+
+    let card = Shape::rounded_rect(
+        [
+            (origin_x + 18.0, origin_y + 14.0),
+            (origin_x + 56.0, origin_y + 52.0),
+        ],
+        BorderRadii::new(8.0),
+        Stroke::default(),
+    );
+    let card_id = renderer
+        .add_shape(
+            card,
+            None,
+            Some(67_067),
+            ShapeDrawCommandOptions::new().color(Color::rgba(75, 125, 235, 150)),
+        )
+        .unwrap();
+    renderer
+        .set_shape_effect(
+            card_id,
+            DOWNSAMPLED_DROP_SHADOW_EFFECT_ID,
+            &[],
+            ShapeEffectConfig::new()
+                .outsets(8.0, 8.0, 20.0, 22.0)
+                .downsample(0.5),
+        )
+        .expect("Failed to attach downsampled drop shadow effect");
+    let backdrop_blur_params = BlurParams {
+        radius: 5.0,
+        _pad: 0.0,
+        tex_size: [38.0, 38.0],
+    };
+    renderer
+        .set_shape_backdrop_effect(
+            card_id,
+            BLUR_EFFECT_ID,
+            bytemuck::bytes_of(&backdrop_blur_params),
+            BackdropEffectConfig::default(),
+        )
+        .expect("Failed to attach backdrop blur to downsampled shadow card");
+
+    vec![
+        PixelExpectation::opaque(
+            origin_x as u32 + 10,
+            origin_y as u32 + 20,
+            245,
+            190,
+            70,
+            "t67_backing_shape_is_visible",
+        ),
+        PixelExpectation::opaque_approx(
+            origin_x as u32 + 62,
+            origin_y as u32 + 35,
+            191,
+            148,
+            53,
+            12,
+            "t67_backing_shape_visible_through_shadow",
+        ),
+        PixelExpectation::opaque_approx(
+            origin_x as u32 + 35,
+            origin_y as u32 + 30,
+            115,
+            122,
+            187,
+            12,
+            "t67_translucent_card_tints_blurred_backdrop",
+        ),
+        PixelExpectation::opaque_approx(
+            origin_x as u32 + 35,
+            origin_y as u32 + 41,
+            117,
+            129,
+            195,
+            12,
+            "t67_backdrop_edge_blurs_inside_card",
+        ),
+        PixelExpectation::opaque(
+            origin_x as u32 + 10,
+            origin_y as u32 + 41,
+            245,
+            190,
+            70,
+            "t67_backdrop_edge_stays_sharp_outside_card",
+        ),
+        PixelExpectation::opaque(
+            origin_x as u32 + 10,
+            origin_y as u32 + 44,
+            255,
+            255,
+            255,
+            "t67_below_backdrop_edge_stays_white_outside_card",
+        ),
+        PixelExpectation::opaque_approx(
+            origin_x as u32 + 62,
+            origin_y as u32 + 57,
+            234,
+            234,
+            234,
+            12,
+            "t67_shadow_has_soft_diagonal_falloff",
+        ),
+        PixelExpectation::opaque_approx(
+            origin_x as u32 + 42,
+            origin_y as u32 + 57,
+            170,
+            170,
+            170,
+            12,
+            "t67_shadow_body_visible_below_card",
+        ),
+        PixelExpectation::opaque(
+            origin_x as u32 + 75,
+            origin_y as u32 + 10,
+            255,
+            255,
+            255,
+            "t67_shadow_outsets_remain_transparent",
         ),
     ]
 }

--- a/grafo-test-scenes/src/shaders.rs
+++ b/grafo-test-scenes/src/shaders.rs
@@ -127,3 +127,51 @@ fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
     return vec4<f32>(0.0, 0.0, 0.0, alpha);
 }
 "#;
+
+/// Horizontal blur tuned for half-resolution shape-effect masks: half the sigma of
+/// `DROP_SHADOW_HORIZONTAL_BLUR_WGSL`, so the bilinearly upscaled result matches it.
+pub const DOWNSAMPLED_DROP_SHADOW_HORIZONTAL_BLUR_WGSL: &str = r#"
+@fragment
+fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    let dimensions = vec2<f32>(textureDimensions(t_input));
+    let pixel = vec2<f32>(1.0 / dimensions.x, 0.0);
+    let sigma = 1.0;
+    var color = vec4<f32>(0.0);
+    var total_weight = 0.0;
+
+    for (var sample_offset = -5; sample_offset <= 5; sample_offset++) {
+        let distance = f32(sample_offset);
+        let weight = exp(-(distance * distance) / (2.0 * sigma * sigma));
+        color += textureSample(t_input, s_input, uv + pixel * distance) * weight;
+        total_weight += weight;
+    }
+
+    return color / total_weight;
+}
+"#;
+
+/// Vertical blur, offset, and tint tuned for half-resolution shape-effect masks:
+/// half the sigma and offset of `DROP_SHADOW_VERTICAL_TINT_WGSL`, so the bilinearly
+/// upscaled result lands at the same screen position.
+pub const DOWNSAMPLED_DROP_SHADOW_VERTICAL_TINT_WGSL: &str = r#"
+@fragment
+fn effect_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    let dimensions = vec2<f32>(textureDimensions(t_input));
+    let pixel = vec2<f32>(0.0, 1.0 / dimensions.y);
+    let shadow_offset = vec2<f32>(3.5, 4.0) / dimensions;
+    let sigma = 1.0;
+    var coverage = 0.0;
+    var total_weight = 0.0;
+
+    for (var sample_offset = -5; sample_offset <= 5; sample_offset++) {
+        let distance = f32(sample_offset);
+        let weight = exp(-(distance * distance) / (2.0 * sigma * sigma));
+        coverage += textureSample(t_input, s_input, uv - shadow_offset + pixel * distance).a
+            * weight;
+        total_weight += weight;
+    }
+
+    let alpha = 0.65 * coverage / total_weight;
+    return vec4<f32>(0.0, 0.0, 0.0, alpha);
+}
+"#;

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -98,7 +98,7 @@ impl BackdropEffectConfig {
 }
 
 /// Padding around a shape's local bounds for a cached shape effect.
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ShapeEffectConfig {
     /// Logical-space distance added to the left of the shape's local bounds.
     pub left_outset: f32,
@@ -108,6 +108,24 @@ pub struct ShapeEffectConfig {
     pub right_outset: f32,
     /// Logical-space distance added below the shape's local bounds.
     pub bottom_outset: f32,
+    /// Scale factor applied to the mask and effect textures before running the
+    /// effect. `1.0` keeps full resolution, `0.5` halves each axis, and so on.
+    /// The smaller result texture is bilinearly upscaled to the shape's full
+    /// bounds when drawn. Effect shaders operate in texels of the downsampled
+    /// texture, so texel-based radii and offsets scale up visually.
+    pub downsample: f32,
+}
+
+impl Default for ShapeEffectConfig {
+    fn default() -> Self {
+        Self {
+            left_outset: 0.0,
+            top_outset: 0.0,
+            right_outset: 0.0,
+            bottom_outset: 0.0,
+            downsample: 1.0,
+        }
+    }
 }
 
 impl ShapeEffectConfig {
@@ -130,6 +148,14 @@ impl ShapeEffectConfig {
         self.top_outset = top;
         self.right_outset = right;
         self.bottom_outset = bottom;
+        self
+    }
+
+    /// Sets the rasterization scale for the mask and effect textures.
+    /// Must be in the range `(0.0, 1.0]`; values below `1.0` render the effect
+    /// at reduced resolution and bilinearly upscale it when drawing.
+    pub fn downsample(mut self, downsample: f32) -> Self {
+        self.downsample = downsample;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,18 @@
 //!                         Err(
 //!                             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
 //!                         ) => renderer.resize(renderer.size()),
+//!                         Err(
+//!                             wgpu::CurrentSurfaceTexture::Timeout
+//!                                 | wgpu::CurrentSurfaceTexture::Occluded,
+//!                         ) => {
+//!                             // The window is not visible yet (still appearing, minimized, or
+//!                             // fully covered). Ask for another redraw instead of dropping the
+//!                             // frame — winit does not request one when the window becomes
+//!                             // visible again.
+//!                             if let Some(window) = &self.window {
+//!                                 window.request_redraw();
+//!                             }
+//!                         }
 //!                         Err(e) => eprintln!("{:?}", e),
 //!                     }
 //!                 }

--- a/src/renderer/effects.rs
+++ b/src/renderer/effects.rs
@@ -82,6 +82,13 @@ fn validate_backdrop_config(config: &effect::BackdropEffectConfig) -> Result<(),
 }
 
 fn validate_shape_effect_config(config: &effect::ShapeEffectConfig) -> Result<(), EffectError> {
+    if !(config.downsample > 0.0 && config.downsample <= 1.0) {
+        return Err(EffectError::InvalidParams(format!(
+            "shape effect downsample must be in the range (0.0, 1.0], got {}",
+            config.downsample
+        )));
+    }
+
     let outsets = [
         config.left_outset,
         config.top_outset,
@@ -661,5 +668,21 @@ mod tests {
             ))
             .is_err()
         );
+    }
+
+    #[test]
+    fn validate_shape_effect_config_rejects_out_of_range_downsample() {
+        for downsample in [0.0, -0.5, f32::NAN, 1.5] {
+            assert!(
+                validate_shape_effect_config(&ShapeEffectConfig::new().downsample(downsample))
+                    .is_err()
+            );
+        }
+        for downsample in [1.0, 0.5, f32::EPSILON] {
+            assert!(
+                validate_shape_effect_config(&ShapeEffectConfig::new().downsample(downsample))
+                    .is_ok()
+            );
+        }
     }
 }

--- a/src/renderer/passes.rs
+++ b/src/renderer/passes.rs
@@ -921,7 +921,10 @@ fn compute_backdrop_capture_region(
     })
 }
 
-fn compute_downsampled_dimensions(capture_size: (u32, u32), downsample: f32) -> (u32, u32) {
+pub(super) fn compute_downsampled_dimensions(
+    capture_size: (u32, u32),
+    downsample: f32,
+) -> (u32, u32) {
     (
         ((capture_size.0 as f32) * downsample).ceil().max(1.0) as u32,
         ((capture_size.1 as f32) * downsample).ceil().max(1.0) as u32,

--- a/src/renderer/shape_effects.rs
+++ b/src/renderer/shape_effects.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "render_metrics")]
 use super::metrics::ShapeEffectCacheMetrics;
-use super::passes::{apply_effect_passes, EffectPassRunConfig};
+use super::passes::{apply_effect_passes, compute_downsampled_dimensions, EffectPassRunConfig};
 use super::types::DrawCommand;
 use super::Renderer;
 use crate::cache::{CachedTessellation, FrameCache};
@@ -37,7 +37,9 @@ pub(super) struct ShapeEffectRasterRect {
     /// screen position: node transforms are applied later, so moving a shape on
     /// screen does not change this value.
     pub local_physical_origin: [i32; 2],
-    pub physical_size: [u32; 2],
+    /// Mask/effect texture size in texels. Smaller than the full-resolution
+    /// physical extent when the effect config downsamples the rasterization.
+    pub texture_size: [u32; 2],
     pub local_bounds: [(f32, f32); 2],
 }
 
@@ -80,6 +82,9 @@ pub(super) fn compute_shape_effect_raster_rect(
         || scale_factor <= 0.0
         || !fringe_width.is_finite()
         || fringe_width < 0.0
+        || !config.downsample.is_finite()
+        || config.downsample <= 0.0
+        || config.downsample > 1.0
         || !bounds_and_outsets.iter().all(|value| value.is_finite())
     {
         return None;
@@ -125,10 +130,11 @@ pub(super) fn compute_shape_effect_raster_rect(
         return None;
     }
 
-    let physical_size = [physical_width as u32, physical_height as u32];
+    let full_resolution_size = (physical_width as u32, physical_height as u32);
+    let texture_size = compute_downsampled_dimensions(full_resolution_size, config.downsample);
     Some(ShapeEffectRasterRect {
         local_physical_origin,
-        physical_size,
+        texture_size: [texture_size.0, texture_size.1],
         local_bounds: [
             (
                 physical_minimum_x as f32 / scale_factor as f32,
@@ -153,6 +159,7 @@ pub(super) struct ShapeEffectCacheKey {
     pub raster_size: [u32; 2],
     pub scale_factor_bits: u64,
     pub fringe_width_bits: u32,
+    pub downsample_bits: u32,
     pub texture_format: wgpu::TextureFormat,
 }
 
@@ -165,6 +172,7 @@ impl PartialEq for ShapeEffectCacheKey {
             && self.raster_size == other.raster_size
             && self.scale_factor_bits == other.scale_factor_bits
             && self.fringe_width_bits == other.fringe_width_bits
+            && self.downsample_bits == other.downsample_bits
             && self.texture_format == other.texture_format
     }
 }
@@ -180,6 +188,7 @@ impl Hash for ShapeEffectCacheKey {
         self.raster_size.hash(state);
         self.scale_factor_bits.hash(state);
         self.fringe_width_bits.hash(state);
+        self.downsample_bits.hash(state);
         self.texture_format.hash(state);
     }
 }
@@ -198,6 +207,7 @@ pub(super) struct ShapeEffectMaskCacheKey {
     pub raster_size: [u32; 2],
     pub scale_factor_bits: u64,
     pub fringe_width_bits: u32,
+    pub downsample_bits: u32,
     pub texture_format: wgpu::TextureFormat,
 }
 
@@ -208,6 +218,7 @@ impl PartialEq for ShapeEffectMaskCacheKey {
             && self.raster_size == other.raster_size
             && self.scale_factor_bits == other.scale_factor_bits
             && self.fringe_width_bits == other.fringe_width_bits
+            && self.downsample_bits == other.downsample_bits
             && self.texture_format == other.texture_format
     }
 }
@@ -221,6 +232,7 @@ impl Hash for ShapeEffectMaskCacheKey {
         self.raster_size.hash(state);
         self.scale_factor_bits.hash(state);
         self.fringe_width_bits.hash(state);
+        self.downsample_bits.hash(state);
         self.texture_format.hash(state);
     }
 }
@@ -425,7 +437,7 @@ impl<'a> Renderer<'a> {
                 );
                 continue;
             };
-            let [width, height] = raster_rect.physical_size;
+            let [width, height] = raster_rect.texture_size;
             let texel_count = u64::from(width).saturating_mul(u64::from(height));
             if width > maximum_texture_dimension
                 || height > maximum_texture_dimension
@@ -525,16 +537,17 @@ impl<'a> Renderer<'a> {
             ) else {
                 continue;
             };
-            let [width, height] = raster_rect.physical_size;
+            let [width, height] = raster_rect.texture_size;
 
             let cache_key = ShapeEffectCacheKey {
                 effect_id: shape_effect_instance.effect_id,
                 tessellation: Arc::clone(&cached_shape.cached_shape.tessellation),
                 params: Arc::clone(&shape_effect_instance.params),
                 local_raster_origin: raster_rect.local_physical_origin,
-                raster_size: raster_rect.physical_size,
+                raster_size: raster_rect.texture_size,
                 scale_factor_bits: self.scale_factor.to_bits(),
                 fringe_width_bits: self.fringe_width.to_bits(),
+                downsample_bits: shape_effect_instance.config.downsample.to_bits(),
                 texture_format: self.config.format,
             };
             if let Some(cached_result) = self.shape_effect_cache.get(&cache_key) {
@@ -567,9 +580,10 @@ impl<'a> Renderer<'a> {
             let mask_cache_key = ShapeEffectMaskCacheKey {
                 tessellation: Arc::clone(&cached_shape.cached_shape.tessellation),
                 local_raster_origin: raster_rect.local_physical_origin,
-                raster_size: raster_rect.physical_size,
+                raster_size: raster_rect.texture_size,
                 scale_factor_bits: self.scale_factor.to_bits(),
                 fringe_width_bits: self.fringe_width.to_bits(),
+                downsample_bits: shape_effect_instance.config.downsample.to_bits(),
                 texture_format: self.config.format,
             };
             let cached_mask = if let Some(cached_mask) =
@@ -729,6 +743,7 @@ mod tests {
             raster_size: [12, 12],
             scale_factor_bits: 1.0f64.to_bits(),
             fringe_width_bits: 0.75f32.to_bits(),
+            downsample_bits: 1.0f32.to_bits(),
             texture_format: wgpu::TextureFormat::Bgra8UnormSrgb,
         }
     }
@@ -744,8 +759,62 @@ mod tests {
         .unwrap();
 
         assert_eq!(raster_rect.local_physical_origin, [-1, 0]);
-        assert_eq!(raster_rect.physical_size, [29, 50]);
+        assert_eq!(raster_rect.texture_size, [29, 50]);
         assert_eq!(raster_rect.local_bounds, [(-0.5, 0.0), (14.0, 25.0)]);
+    }
+
+    #[test]
+    fn raster_rect_downsample_shrinks_texture_but_not_coverage() {
+        let full_resolution = compute_shape_effect_raster_rect(
+            [(1.25, 2.75), (10.1, 20.2)],
+            ShapeEffectConfig::new().outsets(1.0, 2.0, 3.0, 4.0),
+            2.0,
+            0.75,
+        )
+        .unwrap();
+        let downsampled = compute_shape_effect_raster_rect(
+            [(1.25, 2.75), (10.1, 20.2)],
+            ShapeEffectConfig::new()
+                .outsets(1.0, 2.0, 3.0, 4.0)
+                .downsample(0.5),
+            2.0,
+            0.75,
+        )
+        .unwrap();
+
+        assert_eq!(downsampled.texture_size, [15, 25]);
+        assert_eq!(
+            downsampled.local_physical_origin,
+            full_resolution.local_physical_origin
+        );
+        assert_eq!(downsampled.local_bounds, full_resolution.local_bounds);
+    }
+
+    #[test]
+    fn raster_rect_downsample_keeps_at_least_one_texel() {
+        let raster_rect = compute_shape_effect_raster_rect(
+            [(0.0, 0.0), (1.0, 1.0)],
+            ShapeEffectConfig::new().downsample(0.1),
+            1.0,
+            0.75,
+        )
+        .unwrap();
+
+        assert!(raster_rect.texture_size[0] >= 1);
+        assert!(raster_rect.texture_size[1] >= 1);
+    }
+
+    #[test]
+    fn raster_rect_rejects_out_of_range_downsample() {
+        for downsample in [0.0, -0.5, f32::NAN, 1.5] {
+            assert!(compute_shape_effect_raster_rect(
+                [(0.0, 0.0), (10.0, 10.0)],
+                ShapeEffectConfig::new().downsample(downsample),
+                1.0,
+                0.75,
+            )
+            .is_none());
+        }
     }
 
     #[test]
@@ -771,6 +840,18 @@ mod tests {
         assert!(first_key == equal_key);
         assert!(first_key != different_params);
         assert!(first_key != different_tessellation);
+    }
+
+    #[test]
+    fn cache_key_differs_when_only_downsample_changes() {
+        let shared_tessellation = tessellation();
+        let full_resolution_key =
+            cache_key(Arc::clone(&shared_tessellation), Arc::from([1u8, 2, 3, 4]));
+        let mut downsampled_key =
+            cache_key(Arc::clone(&shared_tessellation), Arc::from([1u8, 2, 3, 4]));
+        downsampled_key.downsample_bits = 0.5f32.to_bits();
+
+        assert!(full_resolution_key != downsampled_key);
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable downsampled rendering for shape effects, including validation and bilinear upscaling.
  * Added a half-resolution drop-shadow and backdrop-blur test scene.
* **Bug Fixes**
  * Improved recovery from temporary occlusion and frame timeouts with queued or delayed redraw retries.
  * Continued resizing automatically when rendering surfaces are lost or outdated.
  * Updated rendering examples to handle recoverable surface conditions without panicking.
* **Tests**
  * Added coverage for downsampling limits, texture sizing, cache behavior, and drop-shadow rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->