### PR TITLE
fix: backdrop filter capture size never goes below 0

### DIFF
--- a/src/renderer/passes.rs
+++ b/src/renderer/passes.rs
@@ -850,8 +850,8 @@ fn resolve_capture_region_to_viewport(
     let overlap_right = capture_right.min(physical_size.0 as i32);
     let overlap_bottom = capture_bottom.min(physical_size.1 as i32);
 
-    let overlap_width = overlap_right.saturating_sub(overlap_left) as u32;
-    let overlap_height = overlap_bottom.saturating_sub(overlap_top) as u32;
+    let overlap_width = overlap_right.saturating_sub(overlap_left).max(0) as u32;
+    let overlap_height = overlap_bottom.saturating_sub(overlap_top).max(0) as u32;
     let has_overlap = overlap_width > 0 && overlap_height > 0;
 
     BackdropCaptureRegion {
@@ -1916,6 +1916,17 @@ mod tests {
         assert_eq!(region.copy_source_origin, Some((0, 5)));
         assert_eq!(region.copy_destination_origin, (10, 0));
         assert_eq!(region.copy_size, (30, 20));
+    }
+
+    #[test]
+    fn capture_region_skips_copy_when_fully_offscreen() {
+        let offscreen_right = resolve_capture_region_to_viewport((110, 5, 20, 20), (100, 100));
+        let offscreen_bottom = resolve_capture_region_to_viewport((5, 110, 20, 20), (100, 100));
+
+        assert_eq!(offscreen_right.copy_source_origin, None);
+        assert_eq!(offscreen_right.copy_size, (0, 20));
+        assert_eq!(offscreen_bottom.copy_source_origin, None);
+        assert_eq!(offscreen_bottom.copy_size, (20, 0));
     }
 
     #[test]

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -653,7 +653,7 @@ fn normalized_float_bits(value: f32) -> u32 {
 fn build_boundary_data(vertices: &[CustomVertex], indices: &[u16], scratch: &mut AaFringeScratch) {
     scratch.clear();
 
-    for (triangle_index, tri) in indices.chunks_exact(3).enumerate() {
+    for (triangle_index, tri) in indices.as_chunks::<3>().0.iter().enumerate() {
         let a = tri[0];
         let b = tri[1];
         let c = tri[2];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed backdrop viewport overlap handling for fully offscreen capture regions.
  - Prevented invalid overlap values from affecting backdrop rendering.
- **Tests**
  - Added coverage verifying that fully offscreen regions produce no backdrop source and zero overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->