### PR TITLE
fix: rollback WGPU back to 0.25, as 0.30 introduced color issues and crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -245,18 +245,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.9.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -275,6 +275,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -283,21 +286,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2 0.6.3",
 ]
 
 [[package]]
@@ -469,9 +469,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.13.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
@@ -845,12 +845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1029,17 +1023,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-allocator"
-version = "0.28.0"
+name = "gpu-alloc"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
 dependencies = [
- "ash",
- "hashbrown 0.16.1",
+ "bitflags 2.9.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
  "log",
  "presser",
- "thiserror 2.0.18",
- "windows 0.58.0",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.9.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1096,18 +1127,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.4",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1115,9 +1135,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -1130,6 +1147,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "humantime"
@@ -1452,6 +1475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1509,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.9.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,40 +1541,27 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "30.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.9.1",
- "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.2",
+ "hexf-parse",
  "indexmap",
- "libm",
  "log",
- "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash",
  "spirv",
+ "strum",
  "thiserror 2.0.18",
  "unicode-ident",
-]
-
-[[package]]
-name = "naga-types"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
-dependencies = [
- "hashbrown 0.17.1",
- "indexmap",
- "rustc-hash",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1539,7 +1573,7 @@ dependencies = [
  "bitflags 2.9.1",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1550,6 +1584,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -1655,6 +1698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -1702,7 +1754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -1714,7 +1766,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1726,7 +1778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1761,10 +1813,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1773,7 +1825,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -1792,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -1826,7 +1878,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation 0.2.2",
@@ -1839,21 +1891,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.2",
- "objc2 0.6.3",
- "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1863,10 +1903,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1878,9 +1918,7 @@ dependencies = [
  "bitflags 2.9.1",
  "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation 0.3.2",
- "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -1900,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -1920,7 +1958,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1932,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2117,15 +2155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,18 +2330,6 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "raw-window-metal"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
-dependencies = [
- "objc2 0.6.3",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "objc2-quartz-core 0.3.2",
-]
 
 [[package]]
 name = "rayon"
@@ -2633,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.4.0+sdk-1.4.341.0"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -2651,6 +2668,28 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.93",
+]
 
 [[package]]
 name = "syn"
@@ -3147,17 +3186,15 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "30.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
+checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
- "bytemuck",
- "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.2",
  "js-sys",
  "log",
  "naga",
@@ -3177,22 +3214,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "30.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
+checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
  "bitflags 2.9.1",
- "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.2",
  "indexmap",
  "log",
  "naga",
- "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -3205,116 +3240,94 @@ dependencies = [
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
- "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "30.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
+checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "30.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
+checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "30.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "30.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
+checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.9.1",
- "block2 0.6.2",
+ "block",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
+ "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
+ "gpu-alloc",
  "gpu-allocator",
- "hashbrown 0.17.1",
+ "gpu-descriptor",
+ "hashbrown 0.15.2",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
+ "metal",
  "naga",
- "naga-types",
- "ndk-sys",
- "objc2 0.6.3",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation 0.3.2",
- "objc2-metal 0.3.2",
- "objc2-quartz-core 0.3.2",
- "once_cell",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
  "ordered-float",
  "parking_lot",
  "portable-atomic",
- "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
- "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
- "static_assertions",
  "thiserror 2.0.18",
  "wasm-bindgen",
- "wayland-sys",
  "web-sys",
- "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
- "windows-result 0.4.1",
-]
-
-[[package]]
-name = "wgpu-naga-bridge"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
-dependencies = [
- "naga",
- "wgpu-types",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "30.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
  "js-sys",
  "log",
- "naga-types",
- "raw-window-handle",
- "static_assertions",
+ "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -3355,29 +3368,8 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.58.0",
+ "windows-core",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core 0.62.2",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3386,35 +3378,11 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -3422,17 +3390,6 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3451,31 +3408,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -3487,31 +3423,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -3594,15 +3512,6 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -3747,7 +3656,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.9.1",
- "block2 0.5.1",
+ "block2",
  "bytemuck",
  "calloop",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 bytemuck = "1.23"
-wgpu = "30.0"
+wgpu = "25.0"
 ahash = "0.8"
 lyon = { version = "1.0"}
 easy-tree = { version = "0.3" }

--- a/examples/backdrop_blur.rs
+++ b/examples/backdrop_blur.rs
@@ -291,14 +291,11 @@ impl<'a> ApplicationHandler for App<'a> {
                     Ok(_) => {
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -107,13 +107,10 @@ impl<'a> ApplicationHandler for App<'a> {
                     Ok(_) => {
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or
                         // fully covered). Ask for another redraw instead of dropping the
                         // frame for good — winit does not request one when the window

--- a/examples/bench_render_loop.rs
+++ b/examples/bench_render_loop.rs
@@ -487,18 +487,12 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                         let renderer = self.renderer.as_mut().unwrap();
                         match renderer.render() {
                             Ok(_) => {}
-                            Err(
-                                wgpu::CurrentSurfaceTexture::Timeout
-                                | wgpu::CurrentSurfaceTexture::Occluded,
-                            ) => {
+                            Err(wgpu::SurfaceError::Timeout) => {
                                 // Window not visible — skip without counting the frame.
                                 window.request_redraw();
                                 return;
                             }
-                            Err(
-                                wgpu::CurrentSurfaceTexture::Lost
-                                | wgpu::CurrentSurfaceTexture::Outdated,
-                            ) => {
+                            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                                 let size = renderer.size();
                                 renderer.resize(size);
                                 window.request_redraw();
@@ -523,18 +517,12 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                             let frame_start = Instant::now();
                             match renderer.render() {
                                 Ok(_) => {}
-                                Err(
-                                    wgpu::CurrentSurfaceTexture::Timeout
-                                    | wgpu::CurrentSurfaceTexture::Occluded,
-                                ) => {
+                                Err(wgpu::SurfaceError::Timeout) => {
                                     // Window not visible — skip without measuring the frame.
                                     window.request_redraw();
                                     return;
                                 }
-                                Err(
-                                    wgpu::CurrentSurfaceTexture::Lost
-                                    | wgpu::CurrentSurfaceTexture::Outdated,
-                                ) => {
+                                Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                                     let size = renderer.size();
                                     renderer.resize(size);
                                     window.request_redraw();
@@ -570,19 +558,13 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                         build_scene(renderer);
                         match renderer.render() {
                             Ok(_) => {}
-                            Err(
-                                wgpu::CurrentSurfaceTexture::Timeout
-                                | wgpu::CurrentSurfaceTexture::Occluded,
-                            ) => {
+                            Err(wgpu::SurfaceError::Timeout) => {
                                 // Window not visible — skip without counting the frame.
                                 renderer.clear_draw_queue();
                                 window.request_redraw();
                                 return;
                             }
-                            Err(
-                                wgpu::CurrentSurfaceTexture::Lost
-                                | wgpu::CurrentSurfaceTexture::Outdated,
-                            ) => {
+                            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                                 renderer.clear_draw_queue();
                                 let size = renderer.size();
                                 renderer.resize(size);
@@ -613,19 +595,13 @@ impl<'a> ApplicationHandler for BenchApp<'a> {
                             let frame_start = Instant::now();
                             match renderer.render() {
                                 Ok(_) => {}
-                                Err(
-                                    wgpu::CurrentSurfaceTexture::Timeout
-                                    | wgpu::CurrentSurfaceTexture::Occluded,
-                                ) => {
+                                Err(wgpu::SurfaceError::Timeout) => {
                                     // Window not visible — skip without measuring the frame.
                                     renderer.clear_draw_queue();
                                     window.request_redraw();
                                     return;
                                 }
-                                Err(
-                                    wgpu::CurrentSurfaceTexture::Lost
-                                    | wgpu::CurrentSurfaceTexture::Outdated,
-                                ) => {
+                                Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                                     renderer.clear_draw_queue();
                                     let size = renderer.size();
                                     renderer.resize(size);

--- a/examples/box_shadow.rs
+++ b/examples/box_shadow.rs
@@ -305,14 +305,11 @@ impl<'a> ApplicationHandler for App<'a> {
                     Ok(_) => {
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.

--- a/examples/gaussian_blur.rs
+++ b/examples/gaussian_blur.rs
@@ -273,14 +273,11 @@ impl<'a> ApplicationHandler for App<'a> {
                     Ok(_) => {
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.

--- a/examples/group_opacity.rs
+++ b/examples/group_opacity.rs
@@ -204,14 +204,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/msaa.rs
+++ b/examples/msaa.rs
@@ -187,14 +187,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/multi_texture.rs
+++ b/examples/multi_texture.rs
@@ -136,16 +136,11 @@ impl ApplicationHandler for App {
                     Ok(_) => {
                         self.redraw_retry_at = None;
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => {
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                         let size = renderer.size();
                         renderer.resize(size);
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/shadow_and_blur.rs
+++ b/examples/shadow_and_blur.rs
@@ -373,14 +373,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/shape_texturing.rs
+++ b/examples/shape_texturing.rs
@@ -149,14 +149,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/star_wars_tilt.rs
+++ b/examples/star_wars_tilt.rs
@@ -230,17 +230,11 @@ impl<'a> ApplicationHandler for App<'a> {
 
                     match renderer.render() {
                         Ok(_) => {}
-                        Err(
-                            wgpu::CurrentSurfaceTexture::Lost
-                            | wgpu::CurrentSurfaceTexture::Outdated,
-                        ) => {
+                        Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                             let size = renderer.size();
                             renderer.resize(size);
                         }
-                        Err(
-                            wgpu::CurrentSurfaceTexture::Timeout
-                            | wgpu::CurrentSurfaceTexture::Occluded,
-                        ) => {
+                        Err(wgpu::SurfaceError::Timeout) => {
                             // The window is not visible yet (still appearing, minimized, or
                             // fully covered). Ask for another redraw instead of dropping the
                             // frame for good — winit does not request one when the window

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -613,14 +613,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         renderer.clear_draw_queue();
                         window.request_redraw();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/video_playback.rs
+++ b/examples/video_playback.rs
@@ -110,8 +110,8 @@ pub fn main() {
     //                     Ok(_) => {
     //                         renderer.clear_draw_queue();
     //                     }
-    //                     Err(wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated) => renderer.resize(renderer.size()),
-    //                     Err(wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded) => {
+    //                     Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => renderer.resize(renderer.size()),
+    //                     Err(wgpu::SurfaceError::Timeout) => {
     //                         // The window is not visible yet (still appearing, minimized, or fully
     //                         // covered). Ask for another redraw instead of dropping the frame for
     //                         // good — winit does not request one when the window becomes visible.

--- a/examples/visual_test_grid.rs
+++ b/examples/visual_test_grid.rs
@@ -82,13 +82,10 @@ impl<'a> ApplicationHandler for App<'a> {
                     Ok(_) => {
                         self.redraw_retry_at = None;
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -272,14 +272,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         self.redraw_retry_at = None;
                         renderer.clear_draw_queue();
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => renderer.resize(renderer.size()),
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                        renderer.resize(renderer.size())
+                    }
 
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Retry shortly instead of busy-looping redraws — winit does
                         // not request one when the window becomes visible again. `WaitUntil`

--- a/examples/winit_transparency.rs
+++ b/examples/winit_transparency.rs
@@ -102,16 +102,11 @@ impl<'a> ApplicationHandler for App<'a> {
                         renderer.clear_draw_queue();
                         println!("Render time: {:?}", timer.elapsed());
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
-                    ) => {
+                    Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
                         println!("Surface lost or outdated, resizing...");
                         renderer.resize(renderer.size())
                     }
-                    Err(
-                        wgpu::CurrentSurfaceTexture::Timeout
-                        | wgpu::CurrentSurfaceTexture::Occluded,
-                    ) => {
+                    Err(wgpu::SurfaceError::Timeout) => {
                         // The window is not visible yet (still appearing, minimized, or fully
                         // covered). Ask for another redraw instead of dropping the frame for
                         // good — winit does not request one when the window becomes visible.

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -566,18 +566,18 @@ pub(crate) fn compile_effect_pipeline(
         // if this particular pass references it.
         let layout_label = format!("effect_pass{i}_layout");
         let pipeline_layout = if pass_has_params {
-            let bind_group_layouts = [Some(&input_bgl), Some(params_bgl.as_ref().unwrap())];
+            let bind_group_layouts = [&input_bgl, params_bgl.as_ref().unwrap()];
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some(&layout_label),
                 bind_group_layouts: &bind_group_layouts,
-                immediate_size: 0,
+                push_constant_ranges: &[],
             })
         } else {
-            let bind_group_layouts = [Some(&input_bgl)];
+            let bind_group_layouts = [&input_bgl];
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some(&layout_label),
                 bind_group_layouts: &bind_group_layouts,
-                immediate_size: 0,
+                push_constant_ranges: &[],
             })
         };
 
@@ -618,7 +618,7 @@ pub(crate) fn compile_effect_pipeline(
             },
             depth_stencil: None, // Effect apply pass has no stencil
             multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
+            multiview: None,
             cache: None,
         });
 
@@ -655,8 +655,8 @@ pub(crate) fn compile_composite_pipeline(
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("composite_pipeline_layout"),
-        bind_group_layouts: &[Some(&input_bgl)],
-        immediate_size: 0,
+        bind_group_layouts: &[&input_bgl],
+        push_constant_ranges: &[],
     });
 
     // Stencil: compare Equal, pass_op Keep (respects parent clipping, no stencil modification)
@@ -703,8 +703,8 @@ pub(crate) fn compile_composite_pipeline(
         },
         depth_stencil: Some(wgpu::DepthStencilState {
             format: wgpu::TextureFormat::Depth24PlusStencil8,
-            depth_write_enabled: Some(false),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_write_enabled: false,
+            depth_compare: wgpu::CompareFunction::Always,
             stencil: wgpu::StencilState {
                 front: stencil_face,
                 back: stencil_face,
@@ -714,7 +714,7 @@ pub(crate) fn compile_composite_pipeline(
             bias: wgpu::DepthBiasState::default(),
         }),
         multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     });
 
@@ -737,8 +737,8 @@ pub(crate) fn compile_texture_blit_pipeline(
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("texture_blit_pipeline_layout"),
-        bind_group_layouts: &[Some(input_bind_group_layout)],
-        immediate_size: 0,
+        bind_group_layouts: &[input_bind_group_layout],
+        push_constant_ranges: &[],
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -766,7 +766,7 @@ pub(crate) fn compile_texture_blit_pipeline(
         },
         depth_stencil: None,
         multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -809,8 +809,8 @@ pub(crate) fn compile_backdrop_layer_composite_pipeline(
     });
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("backdrop_layer_composite_pipeline_layout"),
-        bind_group_layouts: &[Some(&bind_group_layout)],
-        immediate_size: 0,
+        bind_group_layouts: &[&bind_group_layout],
+        push_constant_ranges: &[],
     });
     let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: Some("backdrop_layer_composite_pipeline"),
@@ -834,7 +834,7 @@ pub(crate) fn compile_backdrop_layer_composite_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: None,
         multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,9 @@
 //!                             renderer.clear_draw_queue();
 //!                         }
 //!                         Err(
-//!                             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated,
+//!                             wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated,
 //!                         ) => renderer.resize(renderer.size()),
-//!                         Err(
-//!                             wgpu::CurrentSurfaceTexture::Timeout
-//!                                 | wgpu::CurrentSurfaceTexture::Occluded,
-//!                         ) => {
+//!                         Err(wgpu::SurfaceError::Timeout) => {
 //!                             // The window is not visible yet (still appearing, minimized, or
 //!                             // fully covered). Ask for another redraw instead of dropping the
 //!                             // frame — winit does not request one when the window becomes

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -120,8 +120,8 @@ pub fn create_uniform_bind_group_layout(device: &Device) -> BindGroupLayout {
 pub fn create_equal_increment_depth_state() -> wgpu::DepthStencilState {
     wgpu::DepthStencilState {
         format: wgpu::TextureFormat::Depth24PlusStencil8,
-        depth_write_enabled: Some(true),
-        depth_compare: Some(wgpu::CompareFunction::Always),
+        depth_write_enabled: true,
+        depth_compare: wgpu::CompareFunction::Always,
         stencil: create_equal_increment_stencil_state(),
         bias: wgpu::DepthBiasState::default(),
     }
@@ -132,11 +132,11 @@ pub fn create_equal_increment_depth_state() -> wgpu::DepthStencilState {
 pub fn create_depth_stencil_state_for_text() -> wgpu::DepthStencilState {
     wgpu::DepthStencilState {
         format: wgpu::TextureFormat::Depth24PlusStencil8,
-        depth_write_enabled: Some(true),
+        depth_write_enabled: true,
         // Draw only where depth value is equal to the reference value set by the shape when it
         //  was drawn. When the shape is drawn, it always replaces the depth value with the reference
         //  value for itself
-        depth_compare: Some(wgpu::CompareFunction::Equal),
+        depth_compare: wgpu::CompareFunction::Equal,
         stencil: wgpu::StencilState {
             front: StencilFaceState::IGNORE,
             back: StencilFaceState::IGNORE,
@@ -150,8 +150,8 @@ pub fn create_depth_stencil_state_for_text() -> wgpu::DepthStencilState {
 pub fn create_equal_decrement_depth_state() -> wgpu::DepthStencilState {
     wgpu::DepthStencilState {
         format: wgpu::TextureFormat::Depth24PlusStencil8,
-        depth_write_enabled: Some(false),
-        depth_compare: Some(wgpu::CompareFunction::Always),
+        depth_write_enabled: false,
+        depth_compare: wgpu::CompareFunction::Always,
         stencil: create_equal_decrement_stencil_state(),
         bias: wgpu::DepthBiasState::default(),
     }
@@ -174,8 +174,8 @@ pub fn write_on_equal_depth_stencil_state() -> wgpu::DepthStencilState {
 
     wgpu::DepthStencilState {
         format: wgpu::TextureFormat::Depth24PlusStencil8,
-        depth_write_enabled: Some(false),
-        depth_compare: Some(wgpu::CompareFunction::Always),
+        depth_write_enabled: false,
+        depth_compare: wgpu::CompareFunction::Always,
         stencil,
         bias: wgpu::DepthBiasState::default(),
     }
@@ -198,8 +198,8 @@ pub fn always_pass_and_keep_stencil_state() -> wgpu::DepthStencilState {
 
     wgpu::DepthStencilState {
         format: wgpu::TextureFormat::Depth24PlusStencil8,
-        depth_write_enabled: Some(false),
-        depth_compare: Some(wgpu::CompareFunction::Always),
+        depth_write_enabled: false,
+        depth_compare: wgpu::CompareFunction::Always,
         stencil,
         bias: wgpu::DepthBiasState::default(),
     }
@@ -467,11 +467,11 @@ pub fn create_pipeline(
     let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: None,
         bind_group_layouts: &[
-            Some(&bind_group_layout),
-            Some(&texture_bind_group_layout_layer0),
-            Some(&texture_bind_group_layout_layer1),
+            &bind_group_layout,
+            &texture_bind_group_layout_layer0,
+            &texture_bind_group_layout_layer1,
         ],
-        immediate_size: 0,
+        push_constant_ranges: &[],
     });
 
     let fragment_entry_point = match pipeline_type {
@@ -487,10 +487,10 @@ pub fn create_pipeline(
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -506,7 +506,7 @@ pub fn create_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     });
 
@@ -537,12 +537,12 @@ pub fn create_gradient_increment_pipeline(
     let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("gradient_increment_pipeline_layout"),
         bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-            Some(gradient_bgl),
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            gradient_bgl,
         ],
-        immediate_size: 0,
+        push_constant_ranges: &[],
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -553,10 +553,10 @@ pub fn create_gradient_increment_pipeline(
             entry_point: Some("vs_main_gradient"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -587,7 +587,7 @@ pub fn create_gradient_increment_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -639,7 +639,6 @@ pub fn begin_render_pass_with_load_ops<'a, 'b: 'a>(
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: color_texture_view,
             resolve_target,
-            depth_slice: None,
             ops: wgpu::Operations {
                 load: load_operations.color_load_op,
                 store: StoreOp::Store,
@@ -658,7 +657,6 @@ pub fn begin_render_pass_with_load_ops<'a, 'b: 'a>(
         }),
         timestamp_writes: None,
         occlusion_query_set: None,
-        multiview_mask: None,
     })
 }
 
@@ -767,8 +765,8 @@ pub fn create_argb_swizzle_pipeline(device: &Device) -> (BindGroupLayout, Comput
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("argb_swizzle_pl"),
-        bind_group_layouts: &[Some(&bgl)],
-        immediate_size: 0,
+        bind_group_layouts: &[&bgl],
+        push_constant_ranges: &[],
     });
 
     let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -981,12 +979,8 @@ pub fn create_stencil_only_pipeline(
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("stencil_only_pipeline_layout"),
-        bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-        ],
-        immediate_size: 0,
+        bind_group_layouts: &[uniform_bgl, texture_bgl_layer0, texture_bgl_layer1],
+        push_constant_ranges: &[],
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -997,10 +991,10 @@ pub fn create_stencil_only_pipeline(
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1020,7 +1014,7 @@ pub fn create_stencil_only_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -1043,12 +1037,8 @@ pub fn create_stencil_keep_color_pipeline(
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("stencil_keep_color_pipeline_layout"),
-        bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-        ],
-        immediate_size: 0,
+        bind_group_layouts: &[uniform_bgl, texture_bgl_layer0, texture_bgl_layer1],
+        push_constant_ranges: &[],
     });
 
     // Stencil: Equal + Keep (reads stencil for clipping but doesn't modify it)
@@ -1067,10 +1057,10 @@ pub fn create_stencil_keep_color_pipeline(
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1097,8 +1087,8 @@ pub fn create_stencil_keep_color_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: Some(wgpu::DepthStencilState {
             format: wgpu::TextureFormat::Depth24PlusStencil8,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
             stencil: wgpu::StencilState {
                 front: stencil_face,
                 back: stencil_face,
@@ -1112,7 +1102,7 @@ pub fn create_stencil_keep_color_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -1134,12 +1124,12 @@ pub fn create_backdrop_stencil_keep_color_pipeline(
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("backdrop_stencil_keep_color_pipeline_layout"),
         bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-            Some(backdrop_texture_bgl),
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            backdrop_texture_bgl,
         ],
-        immediate_size: 0,
+        push_constant_ranges: &[],
     });
 
     let stencil_face = wgpu::StencilFaceState {
@@ -1157,10 +1147,10 @@ pub fn create_backdrop_stencil_keep_color_pipeline(
             entry_point: Some("vs_main"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1187,8 +1177,8 @@ pub fn create_backdrop_stencil_keep_color_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: Some(wgpu::DepthStencilState {
             format: wgpu::TextureFormat::Depth24PlusStencil8,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
             stencil: wgpu::StencilState {
                 front: stencil_face,
                 back: stencil_face,
@@ -1202,7 +1192,7 @@ pub fn create_backdrop_stencil_keep_color_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -1224,12 +1214,12 @@ pub fn create_gradient_stencil_keep_color_pipeline(
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("gradient_stencil_keep_color_pipeline_layout"),
         bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-            Some(gradient_bgl),
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            gradient_bgl,
         ],
-        immediate_size: 0,
+        push_constant_ranges: &[],
     });
 
     let stencil_face = wgpu::StencilFaceState {
@@ -1247,10 +1237,10 @@ pub fn create_gradient_stencil_keep_color_pipeline(
             entry_point: Some("vs_main_gradient"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1277,8 +1267,8 @@ pub fn create_gradient_stencil_keep_color_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: Some(wgpu::DepthStencilState {
             format: wgpu::TextureFormat::Depth24PlusStencil8,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
             stencil: wgpu::StencilState {
                 front: stencil_face,
                 back: stencil_face,
@@ -1292,7 +1282,7 @@ pub fn create_gradient_stencil_keep_color_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -1314,12 +1304,12 @@ pub fn create_backdrop_gradient_stencil_keep_color_pipeline(
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("backdrop_gradient_stencil_keep_color_pipeline_layout"),
         bind_group_layouts: &[
-            Some(uniform_bgl),
-            Some(texture_bgl_layer0),
-            Some(texture_bgl_layer1),
-            Some(backdrop_gradient_bgl),
+            uniform_bgl,
+            texture_bgl_layer0,
+            texture_bgl_layer1,
+            backdrop_gradient_bgl,
         ],
-        immediate_size: 0,
+        push_constant_ranges: &[],
     });
 
     let stencil_face = wgpu::StencilFaceState {
@@ -1337,10 +1327,10 @@ pub fn create_backdrop_gradient_stencil_keep_color_pipeline(
             entry_point: Some("vs_main_gradient"),
             compilation_options: Default::default(),
             buffers: &[
-                Some(CustomVertex::desc()),
-                Some(InstanceTransform::desc()),
-                Some(InstanceColor::desc()),
-                Some(InstanceMetadata::desc()),
+                CustomVertex::desc(),
+                InstanceTransform::desc(),
+                InstanceColor::desc(),
+                InstanceMetadata::desc(),
             ],
         },
         fragment: Some(wgpu::FragmentState {
@@ -1367,8 +1357,8 @@ pub fn create_backdrop_gradient_stencil_keep_color_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: Some(wgpu::DepthStencilState {
             format: wgpu::TextureFormat::Depth24PlusStencil8,
-            depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Always,
             stencil: wgpu::StencilState {
                 front: stencil_face,
                 back: stencil_face,
@@ -1382,7 +1372,7 @@ pub fn create_backdrop_gradient_stencil_keep_color_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }

--- a/src/renderer/construction.rs
+++ b/src/renderer/construction.rs
@@ -84,16 +84,13 @@ impl RendererContext {
     /// The context deliberately has no surface. A renderer created from it validates and
     /// configures its own surface, so windows can be added later without rebuilding the device.
     pub async fn try_new() -> Result<Self, RendererCreationError> {
-        let instance = Arc::new(wgpu::Instance::new(
-            InstanceDescriptor::new_without_display_handle(),
-        ));
+        let instance = Arc::new(wgpu::Instance::new(&InstanceDescriptor::default()));
         let adapter = Arc::new(
             instance
                 .request_adapter(&wgpu::RequestAdapterOptions {
                     power_preference: wgpu::PowerPreference::HighPerformance,
                     compatible_surface: None,
                     force_fallback_adapter: false,
-                    apply_limit_buckets: false,
                 })
                 .await?,
         );
@@ -107,7 +104,6 @@ impl RendererContext {
                 #[cfg(not(feature = "performance_measurement"))]
                 required_features: wgpu::Features::empty(),
                 required_limits: wgpu::Limits::default(),
-                experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 memory_hints: Default::default(),
                 trace: Default::default(),
             })
@@ -209,7 +205,6 @@ impl<'a> Renderer<'a> {
             } else {
                 wgpu::PresentMode::AutoNoVsync
             },
-            color_space: wgpu::SurfaceColorSpace::Auto,
             desired_maximum_frame_latency: 2,
             alpha_mode,
             view_formats: vec![],
@@ -319,7 +314,7 @@ impl<'a> Renderer<'a> {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
 
@@ -635,7 +630,7 @@ impl<'a> Renderer<'a> {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         });
 
@@ -704,7 +699,7 @@ impl<'a> Renderer<'a> {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         });
 
@@ -785,7 +780,6 @@ impl<'a> Renderer<'a> {
             width: physical_size.0,
             height: physical_size.1,
             present_mode: wgpu::PresentMode::AutoVsync,
-            color_space: wgpu::SurfaceColorSpace::Auto,
             desired_maximum_frame_latency: 2,
             alpha_mode: CompositeAlphaMode::Opaque,
             view_formats: vec![],

--- a/src/renderer/effects.rs
+++ b/src/renderer/effects.rs
@@ -536,7 +536,7 @@ impl<'a> Renderer<'a> {
                 address_mode_w: wgpu::AddressMode::ClampToEdge,
                 mag_filter: wgpu::FilterMode::Linear,
                 min_filter: wgpu::FilterMode::Linear,
-                mipmap_filter: wgpu::MipmapFilterMode::Linear,
+                mipmap_filter: wgpu::FilterMode::Linear,
                 ..Default::default()
             }));
         }

--- a/src/renderer/passes.rs
+++ b/src/renderer/passes.rs
@@ -153,7 +153,6 @@ pub(super) fn apply_effect_passes(
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                 view: output_view,
                 resolve_target: None,
-                depth_slice: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                     store: wgpu::StoreOp::Store,
@@ -162,7 +161,6 @@ pub(super) fn apply_effect_passes(
             depth_stencil_attachment: None,
             timestamp_writes: None,
             occlusion_query_set: None,
-            multiview_mask: None,
         });
 
         pass.set_pipeline(&effect_pass.pipeline);
@@ -941,7 +939,6 @@ fn clear_texture_to_transparent(
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: output_view,
             resolve_target: None,
-            depth_slice: None,
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                 store: wgpu::StoreOp::Store,
@@ -950,7 +947,6 @@ fn clear_texture_to_transparent(
         depth_stencil_attachment: None,
         timestamp_writes: None,
         occlusion_query_set: None,
-        multiview_mask: None,
     });
 }
 
@@ -978,7 +974,6 @@ fn blit_texture_to_texture(
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: output_view,
             resolve_target: None,
-            depth_slice: None,
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                 store: wgpu::StoreOp::Store,
@@ -987,7 +982,6 @@ fn blit_texture_to_texture(
         depth_stencil_attachment: None,
         timestamp_writes: None,
         occlusion_query_set: None,
-        multiview_mask: None,
     });
     render_pass.set_pipeline(pipeline);
     render_pass.set_bind_group(0, &bind_group, &[]);
@@ -1014,7 +1008,6 @@ fn composite_backdrop_foreground_layer(
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: output_view,
             resolve_target: None,
-            depth_slice: None,
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Load,
                 store: wgpu::StoreOp::Store,
@@ -1023,7 +1016,6 @@ fn composite_backdrop_foreground_layer(
         depth_stencil_attachment: None,
         timestamp_writes: None,
         occlusion_query_set: None,
-        multiview_mask: None,
     });
     render_pass.set_pipeline(pipeline);
     render_pass.set_bind_group(0, &bind_group, &[]);

--- a/src/renderer/readback.rs
+++ b/src/renderer/readback.rs
@@ -43,7 +43,7 @@ impl<'a> Renderer<'a> {
             }
         });
 
-        let _ = device.poll(wgpu::PollType::wait_indefinitely());
+        let _ = device.poll(wgpu::MaintainBase::Wait);
 
         let map_result = match receiver.recv() {
             Ok(result) => result,
@@ -58,14 +58,7 @@ impl<'a> Renderer<'a> {
             return;
         }
 
-        let mapped_range = match buffer_slice.get_mapped_range() {
-            Ok(range) => range,
-            Err(error) => {
-                warn!("Failed to get mapped range of readback buffer: {:?}", error);
-                buffer.unmap();
-                return;
-            }
-        };
+        let mapped_range = buffer_slice.get_mapped_range();
         mapped_bytes.extend_from_slice(&mapped_range);
         drop(mapped_range);
         buffer.unmap();

--- a/src/renderer/rendering.rs
+++ b/src/renderer/rendering.rs
@@ -516,12 +516,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
-    /// Renders the draw queue to the surface and presents it.
-    ///
-    /// If the returned outcome is a non-success [`wgpu::CurrentSurfaceTexture`]
-    /// variant (`Lost`, `Outdated`, `Timeout`), the caller should decide what to do with it -
-    /// reconfigure the surface, try again, etc.
-    pub fn render(&mut self) -> Result<(), wgpu::CurrentSurfaceTexture> {
+    pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
         #[cfg(feature = "render_metrics")]
         let frame_render_loop_started_at = std::time::Instant::now();
         self.prepare_render();
@@ -533,12 +528,7 @@ impl<'a> Renderer<'a> {
             .surface
             .as_ref()
             .expect("Cannot call render() on a headless renderer; use render_to_buffer()");
-        let output = match surface.get_current_texture() {
-            // TODO: decide what to do with suboptimal frames
-            wgpu::CurrentSurfaceTexture::Success(frame)
-            | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
-            non_success => return Err(non_success),
-        };
+        let output = surface.get_current_texture()?;
         let output_texture_view = output
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
@@ -548,12 +538,12 @@ impl<'a> Renderer<'a> {
         #[cfg(feature = "render_metrics")]
         let after_submit = std::time::Instant::now();
 
-        self.queue.present(output);
+        output.present();
         #[cfg(feature = "render_metrics")]
         {
             let after_present = std::time::Instant::now();
             // Force GPU completion to measure actual GPU execution time.
-            let _ = self.device.poll(wgpu::PollType::wait_indefinitely());
+            let _ = self.device.poll(wgpu::MaintainBase::Wait);
             let after_gpu_wait = std::time::Instant::now();
 
             let prepare_dur = after_prepare.saturating_duration_since(frame_render_loop_started_at);

--- a/src/renderer/shape_effects.rs
+++ b/src/renderer/shape_effects.rs
@@ -301,8 +301,8 @@ fn create_mask_pipeline(
     });
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("shape_effect_mask_pipeline_layout"),
-        bind_group_layouts: &[Some(bind_group_layout)],
-        immediate_size: 0,
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -312,7 +312,7 @@ fn create_mask_pipeline(
             module: &shader,
             entry_point: Some("mask_vertex"),
             compilation_options: Default::default(),
-            buffers: &[Some(CustomVertex::desc())],
+            buffers: &[CustomVertex::desc()],
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
@@ -327,7 +327,7 @@ fn create_mask_pipeline(
         primitive: wgpu::PrimitiveState::default(),
         depth_stencil: None,
         multisample: wgpu::MultisampleState::default(),
-        multiview_mask: None,
+        multiview: None,
         cache: None,
     })
 }
@@ -626,7 +626,6 @@ impl<'a> Renderer<'a> {
                         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                             view: &mask_texture.color_view,
                             resolve_target: None,
-                            depth_slice: None,
                             ops: wgpu::Operations {
                                 load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                                 store: wgpu::StoreOp::Store,
@@ -635,7 +634,6 @@ impl<'a> Renderer<'a> {
                         depth_stencil_attachment: None,
                         timestamp_writes: None,
                         occlusion_query_set: None,
-                        multiview_mask: None,
                     });
                     render_pass.set_pipeline(&self.shape_effect_resources.mask_pipeline);
                     render_pass.set_bind_group(0, &mask_bind_group, &[]);

--- a/src/texture_manager.rs
+++ b/src/texture_manager.rs
@@ -105,7 +105,7 @@ impl TextureManager {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         })
     }


### PR DESCRIPTION
I've spent the whole day trying to understand what went wrong, and I'm not willing to spend any more for now. Upgrading can wait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated rendering and pipeline integration for the current graphics API.
  * Improved handling of surface loss, outdated surfaces, and rendering timeouts across examples.
  * Rendering retries now occur for timeout conditions, while recoverable surface issues trigger resizing.
* **Bug Fixes**
  * Fixed readback and presentation handling to improve rendering reliability.
  * Updated sampler and pipeline configuration to maintain existing visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->